### PR TITLE
Fix seed-forest.sh to build sembly index before verification

### DIFF
--- a/seed-forest.sh
+++ b/seed-forest.sh
@@ -61,6 +61,10 @@ else
     forester seed
 fi
 
+# Build sembly index
+log "Building sembly index..."
+sembly build 2>/dev/null
+
 # Verify
 if ! sembly search "test" 2>/dev/null | head -1 | grep -q "Found"; then
     echo "❌ Setup verification failed" >&2


### PR DESCRIPTION
I got 
```
Error: sembly::cli::knowledge_index_failed

  × Knowledge index operation failed
  ╰─▶ Index does not exist at /home/fedora/bottlerocket-forest/.sembly/knowledge.db
  help: Use 'sembly build' to create the index

❌ Setup verification failed
```

The fix is to basically run sembly build first to create the index as suggested. 