### PR TITLE
feat: add Go language support for documentation indexing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ sha2 = "0.10"
 text-splitter = { version = "0.28", features = ["markdown", "tokenizers"] }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
+tree-sitter = "0.24"
+tree-sitter-go = "0.23"
 
 # File system and paths
 globset = "0.4"

--- a/crates/crumbly-core/Cargo.toml
+++ b/crates/crumbly-core/Cargo.toml
@@ -32,6 +32,8 @@ syn.workspace = true
 text-splitter.workspace = true
 tokenizers.workspace = true
 toml.workspace = true
+tree-sitter.workspace = true
+tree-sitter-go.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/crumbly-core/src/knowledge/chunking/dispatcher.rs
+++ b/crates/crumbly-core/src/knowledge/chunking/dispatcher.rs
@@ -34,9 +34,14 @@ impl ChunkingDispatcher {
             filter.rust_filter().cloned(),
         )
         .context(StrategyInitFailedSnafu)?;
+        let godoc_chunker = super::godoc::GoDocChunker::from_config_with_filter(
+            config,
+            filter.go_filter().cloned(),
+        )
+        .context(StrategyInitFailedSnafu)?;
 
         Ok(Self {
-            strategies: vec![Box::new(markdown_chunker), Box::new(rustdoc_chunker)],
+            strategies: vec![Box::new(markdown_chunker), Box::new(rustdoc_chunker), Box::new(godoc_chunker)],
         })
     }
 
@@ -63,7 +68,7 @@ pub enum DispatchError {
     #[snafu(display("No chunking strategy available for this file type"))]
     #[diagnostic(
         code(crumbly::chunking::no_strategy_found),
-        help("Only Markdown (.md) and Rust (.rs) files are currently supported")
+        help("Only Markdown (.md), Rust (.rs), and Go (.go) files are currently supported")
     )]
     NoStrategyFound,
 
@@ -140,6 +145,7 @@ mod test {
 
     #[test_case("test.md" ; "markdown file")]
     #[test_case("test.rs" ; "rust file")]
+    #[test_case("test.go" ; "go file")]
     fn test_with_defaults_supports_file_types(file_path: &str) {
         // Given A dispatcher with default strategies
         let config = EmbeddingModelConfig::default();

--- a/crates/crumbly-core/src/knowledge/chunking/godoc/extraction.rs
+++ b/crates/crumbly-core/src/knowledge/chunking/godoc/extraction.rs
@@ -1,0 +1,127 @@
+//! Go documentation extraction utilities.
+
+use tree_sitter::Node;
+
+use crate::knowledge::domain::{GoItemType, GoVisibility, Visibility};
+use crate::knowledge::indexing::GoItemType as FilterGoItemType;
+
+/// Constants for tree-sitter Go node kinds.
+pub mod node_kinds {
+    pub const COMMENT: &str = "comment";
+    pub const IDENTIFIER: &str = "identifier";
+    pub const TYPE_IDENTIFIER: &str = "type_identifier";
+    pub const PACKAGE_CLAUSE: &str = "package_clause";
+    pub const FUNCTION_DECLARATION: &str = "function_declaration";
+    pub const METHOD_DECLARATION: &str = "method_declaration";
+    pub const TYPE_DECLARATION: &str = "type_declaration";
+    pub const CONST_DECLARATION: &str = "const_declaration";
+    pub const VAR_DECLARATION: &str = "var_declaration";
+    pub const STRUCT_TYPE: &str = "struct_type";
+    pub const INTERFACE_TYPE: &str = "interface_type";
+}
+
+/// Extracts doc comments from nodes preceding a declaration.
+pub fn extract_doc_comment(node: Node, source: &[u8]) -> Option<String> {
+    let decl_start_line = node.start_position().row;
+    let mut comments = Vec::new();
+    let mut cursor = node;
+    let mut total_len = 0;
+
+    while let Some(prev) = cursor.prev_sibling() {
+        if prev.kind() == node_kinds::COMMENT {
+            let comment_end_line = prev.end_position().row;
+            if comment_end_line + 1 >= decl_start_line
+                || (!comments.is_empty() && comment_end_line + 1 >= cursor.start_position().row)
+            {
+                let text = prev.utf8_text(source).ok()?;
+                let trimmed = text.trim_start_matches("//").trim();
+                total_len += trimmed.len() + 1;
+                comments.push(trimmed);
+                cursor = prev;
+            } else {
+                break;
+            }
+        } else if prev.kind().contains(node_kinds::COMMENT) {
+            cursor = prev;
+        } else {
+            break;
+        }
+    }
+
+    if comments.is_empty() {
+        return None;
+    }
+
+    comments.reverse();
+    let mut result = String::with_capacity(total_len);
+    for (i, comment) in comments.iter().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        result.push_str(comment);
+    }
+
+    if result.is_empty() { None } else { Some(result) }
+}
+
+/// Extracts the identifier name from a declaration node.
+pub fn extract_identifier(node: Node, source: &[u8]) -> Option<String> {
+    for child in node.children(&mut node.walk()) {
+        if child.kind() == node_kinds::IDENTIFIER || child.kind() == node_kinds::TYPE_IDENTIFIER {
+            return child.utf8_text(source).ok().map(|s| s.to_string());
+        }
+        // For type_declaration, the identifier is inside type_spec
+        if child.kind() == "type_spec" {
+            if let Some(name) = extract_identifier(child, source) {
+                return Some(name);
+            }
+        }
+    }
+    None
+}
+
+/// Returns true if the name is exported (starts with uppercase).
+pub fn is_exported(name: &str) -> bool {
+    name.chars().next().is_some_and(|c| c.is_uppercase())
+}
+
+/// Determines the specific type kind (struct, interface, or generic type).
+pub fn determine_type_kind(node: Node) -> GoItemType {
+    for child in node.children(&mut node.walk()) {
+        match child.kind() {
+            node_kinds::STRUCT_TYPE => return GoItemType::Struct,
+            node_kinds::INTERFACE_TYPE => return GoItemType::Interface,
+            "type_spec" => {
+                let result = determine_type_kind(child);
+                if result != GoItemType::Type {
+                    return result;
+                }
+            }
+            _ => {}
+        }
+    }
+    GoItemType::Type
+}
+
+/// Returns visibility based on whether the name is exported.
+pub fn get_visibility(name: &str) -> (GoVisibility, Visibility) {
+    if is_exported(name) {
+        (GoVisibility::Exported, Visibility::Public)
+    } else {
+        (GoVisibility::Unexported, Visibility::Private)
+    }
+}
+
+/// Converts a GoItemType to the corresponding filter type.
+pub fn to_filter_type(item_type: GoItemType) -> FilterGoItemType {
+    match item_type {
+        GoItemType::Function => FilterGoItemType::Function,
+        GoItemType::Method => FilterGoItemType::Method,
+        GoItemType::Struct => FilterGoItemType::Struct,
+        GoItemType::Interface => FilterGoItemType::Interface,
+        GoItemType::Type => FilterGoItemType::Type,
+        GoItemType::Const => FilterGoItemType::Const,
+        GoItemType::Var => FilterGoItemType::Var,
+        GoItemType::Package => FilterGoItemType::Function, // Package docs always included
+    }
+}

--- a/crates/crumbly-core/src/knowledge/chunking/godoc/mod.rs
+++ b/crates/crumbly-core/src/knowledge/chunking/godoc/mod.rs
@@ -1,0 +1,372 @@
+//! Extracts and chunks Go documentation comments for semantic search.
+//!
+//! Implements chunking for Go source files by extracting doc comments
+//! (comments immediately preceding declarations). Uses `tree-sitter` for parsing
+//! and `text-splitter` for token-aware chunking with overlap.
+//!
+//! Doc comments are extracted from:
+//! - Package-level comments
+//! - Functions, methods, types, constants, variables
+//!
+//! Each chunk preserves metadata including item name, visibility, and signatures.
+
+mod extraction;
+
+use std::path::Path;
+use text_splitter::{ChunkConfig, TextSplitter};
+use tokenizers::Tokenizer;
+use tree_sitter::Parser;
+
+use self::extraction::{node_kinds, extract_doc_comment, extract_identifier, get_visibility, determine_type_kind, to_filter_type};
+use super::{ChunkingError, ChunkingInput, ChunkingStrategy};
+use crate::knowledge::domain::{
+    Chunk, ChunkContent, ChunkContext, ChunkHash, GoDocContext, GoItemType, GoVisibility, ItemName,
+    PackageName, Signature, TokenCount,
+};
+use crate::knowledge::domain::EmbeddingModelConfig;
+use crate::knowledge::indexing::GoFilter;
+
+const PACKAGE_ITEM_NAME: &str = "package";
+
+/// Extracts and chunks Go documentation comments.
+pub struct GoDocChunker {
+    splitter: TextSplitter<Tokenizer>,
+    tokenizer: Tokenizer,
+    filter: Option<GoFilter>,
+}
+
+impl GoDocChunker {
+    /// Initializes chunker with tokenizer and splitter configured for the embedding model.
+    pub fn from_config(config: &EmbeddingModelConfig) -> Result<Self, ChunkingError> {
+        Self::from_config_with_filter(config, None)
+    }
+
+    /// Initializes chunker with tokenizer, splitter, and filtering rules for Go items.
+    pub fn from_config_with_filter(
+        config: &EmbeddingModelConfig,
+        filter: Option<GoFilter>,
+    ) -> Result<Self, ChunkingError> {
+        use super::strategy::chunking_error::*;
+        use snafu::ResultExt;
+
+        let tokenizer = Tokenizer::from_pretrained(&config.model_name, None)
+            .map_err(|e| e as Box<dyn std::error::Error + Send + Sync>)
+            .context(TokenizerInitSnafu)?;
+
+        let tokenizer_for_counting = tokenizer.clone();
+
+        let splitter = TextSplitter::new(
+            ChunkConfig::new(config.max_tokens)
+                .with_sizer(tokenizer)
+                .with_overlap(config.overlap_tokens)
+                .expect("overlap configuration should be valid"),
+        );
+
+        Ok(Self {
+            splitter,
+            tokenizer: tokenizer_for_counting,
+            filter,
+        })
+    }
+
+    fn should_index(&self, name: &str, item_type: GoItemType, doc: &str) -> bool {
+        let Some(ref filter) = self.filter else {
+            return true;
+        };
+        let (_, visibility) = get_visibility(name);
+        let filter_type = to_filter_type(item_type);
+        filter.should_index(&visibility, &filter_type, doc.lines().count())
+    }
+
+    fn create_chunks(
+        &self,
+        text: &str,
+        item_name: ItemName,
+        visibility: GoVisibility,
+        signature: Option<Signature>,
+        item_type: GoItemType,
+        package_name: &Option<PackageName>,
+        input: &ChunkingInput,
+    ) -> Result<Vec<Chunk>, ChunkingError> {
+        use super::strategy::chunking_error::*;
+        use snafu::ResultExt;
+
+        let chunks: Vec<_> = self.splitter.chunks(text).collect();
+        let mut result = Vec::new();
+
+        for chunk_text in chunks {
+            let encoding = self.tokenizer.encode(chunk_text, false)
+                .context(ParseSnafu { file_path: input.source.file_path.to_string() })?;
+            
+            let token_count = encoding.len().max(1);
+            let token_count = TokenCount::try_new(token_count)
+                .map_err(crate::knowledge::error::box_err)
+                .context(ParseSnafu { file_path: input.source.file_path.to_string() })?;
+
+            let chunk_hash = ChunkHash::from_text(chunk_text);
+            let chunk = Chunk::builder()
+                .id(crate::knowledge::domain::ChunkId::new(uuid::Uuid::new_v4()))
+                .chunk_hash(chunk_hash)
+                .file_hash(input.file_hash.clone())
+                .source(input.source.clone())
+                .content(ChunkContent::builder()
+                    .text(chunk_text.to_string())
+                    .token_count(token_count)
+                    .build())
+                .context(ChunkContext::GoDoc(GoDocContext::builder()
+                    .item_name(item_name.clone())
+                    .visibility(visibility)
+                    .maybe_signature(signature.clone())
+                    .item_type(item_type)
+                    .maybe_package_name(package_name.as_ref().cloned())
+                    .build()))
+                .build();
+
+            result.push(chunk);
+        }
+
+        Ok(result)
+    }
+}
+
+impl ChunkingStrategy for GoDocChunker {
+    fn supports(&self, file_path: &Path) -> bool {
+        file_path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext == "go")
+            .unwrap_or(false)
+    }
+
+    fn chunk(&self, input: &ChunkingInput) -> Result<Vec<Chunk>, ChunkingError> {
+        use super::strategy::chunking_error::*;
+        use snafu::ResultExt;
+
+        let content = input.content.as_ref();
+        let file_path = input.source.file_path.to_string();
+
+        let mut parser = Parser::new();
+        parser.set_language(&tree_sitter_go::LANGUAGE.into())
+            .map_err(crate::knowledge::error::box_err)
+            .context(ParseSnafu { file_path: file_path.clone() })?;
+
+        let tree = parser.parse(content, None)
+            .ok_or_else(|| ChunkingError::ParseError {
+                file_path: file_path.clone(),
+                source: "Failed to parse Go source".into(),
+            })?;
+
+        let root = tree.root_node();
+        let source_bytes = content.as_bytes();
+        let mut chunks = Vec::new();
+        let mut package_name = None;
+
+        for node in root.children(&mut root.walk()) {
+            match node.kind() {
+                node_kinds::PACKAGE_CLAUSE => {
+                    if let Some(pkg_node) = node.child_by_field_name("name").or_else(|| node.children(&mut node.walk()).find(|c| c.kind() == "package_identifier")) {
+                        package_name = pkg_node.utf8_text(source_bytes).ok().and_then(|s| PackageName::try_new(s).ok());
+                    }
+                    if let Some(doc) = extract_doc_comment(node, source_bytes) {
+                        chunks.extend(self.create_chunks(
+                            &doc,
+                            ItemName::try_new(PACKAGE_ITEM_NAME).map_err(crate::knowledge::error::box_err).context(ParseSnafu { file_path: file_path.clone() })?,
+                            GoVisibility::Exported,
+                            None,
+                            GoItemType::Package,
+                            &package_name,
+                            input,
+                        )?);
+                    }
+                }
+                node_kinds::FUNCTION_DECLARATION | node_kinds::METHOD_DECLARATION => {
+                    let Some(doc) = extract_doc_comment(node, source_bytes) else { continue };
+                    let Some(name) = extract_identifier(node, source_bytes) else {
+                        // Identifier not found, skipping node
+                        continue;
+                    };
+                    let item_type = if node.kind() == node_kinds::METHOD_DECLARATION { GoItemType::Method } else { GoItemType::Function };
+                    if !self.should_index(&name, item_type, &doc) { continue; }
+                    let (go_vis, _) = get_visibility(&name);
+                    chunks.extend(self.create_chunks(
+                        &doc,
+                        ItemName::try_new(&name).map_err(crate::knowledge::error::box_err).context(ParseSnafu { file_path: file_path.clone() })?,
+                        go_vis,
+                        node.utf8_text(source_bytes).ok().and_then(|s| Signature::try_new(s).ok()),
+                        item_type,
+                        &package_name,
+                        input,
+                    )?);
+                }
+                node_kinds::TYPE_DECLARATION => {
+                    let Some(doc) = extract_doc_comment(node, source_bytes) else { continue };
+                    let Some(name) = extract_identifier(node, source_bytes) else {
+                        // Identifier not found, skipping node
+                        continue;
+                    };
+                    let item_type = determine_type_kind(node);
+                    if !self.should_index(&name, item_type, &doc) { continue; }
+                    let (go_vis, _) = get_visibility(&name);
+                    chunks.extend(self.create_chunks(
+                        &doc,
+                        ItemName::try_new(&name).map_err(crate::knowledge::error::box_err).context(ParseSnafu { file_path: file_path.clone() })?,
+                        go_vis,
+                        None,
+                        item_type,
+                        &package_name,
+                        input,
+                    )?);
+                }
+                node_kinds::CONST_DECLARATION | node_kinds::VAR_DECLARATION => {
+                    let Some(doc) = extract_doc_comment(node, source_bytes) else { continue };
+                    let Some(name) = extract_identifier(node, source_bytes) else {
+                        // Identifier not found, skipping node
+                        continue;
+                    };
+                    let item_type = if node.kind() == node_kinds::CONST_DECLARATION { GoItemType::Const } else { GoItemType::Var };
+                    if !self.should_index(&name, item_type, &doc) { continue; }
+                    let (go_vis, _) = get_visibility(&name);
+                    chunks.extend(self.create_chunks(
+                        &doc,
+                        ItemName::try_new(&name).map_err(crate::knowledge::error::box_err).context(ParseSnafu { file_path: file_path.clone() })?,
+                        go_vis,
+                        None,
+                        item_type,
+                        &package_name,
+                        input,
+                    )?);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(chunks)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge::chunking::ChunkingStrategy;
+    use crate::knowledge::domain::{
+        ChunkContext, ChunkSource, ChunkableContent, FileHash, IndexRelativePath, RepoName,
+    };
+
+    fn test_config() -> EmbeddingModelConfig {
+        EmbeddingModelConfig::default()
+    }
+
+    fn make_input(content: &str) -> ChunkingInput {
+        ChunkingInput {
+            content: ChunkableContent::new(content.to_string()),
+            source: ChunkSource::builder()
+                .file_path(IndexRelativePath::try_new("test.go").unwrap())
+                .repo_name(RepoName::try_new("test").unwrap())
+                .build(),
+            file_hash: FileHash::new([0u8; 32]),
+        }
+    }
+
+    #[test]
+    fn test_supports_go_files() {
+        let chunker = GoDocChunker::from_config(&test_config()).unwrap();
+        assert!(chunker.supports(Path::new("main.go")));
+        assert!(chunker.supports(Path::new("pkg/util.go")));
+        assert!(!chunker.supports(Path::new("main.rs")));
+        assert!(!chunker.supports(Path::new("main.go.bak")));
+    }
+
+    #[test]
+    fn test_extracts_function_doc() {
+        let chunker = GoDocChunker::from_config(&test_config()).unwrap();
+        let input = make_input(r#"
+package main
+
+// Hello prints a greeting.
+// It takes a name parameter.
+func Hello(name string) {
+    println("Hello, " + name)
+}
+"#);
+        let chunks = chunker.chunk(&input).unwrap();
+        assert!(!chunks.is_empty());
+        let ctx = match &chunks[0].context {
+            ChunkContext::GoDoc(ctx) => ctx,
+            _ => panic!("Expected GoDoc context"),
+        };
+        assert_eq!(ctx.item_name.to_string().as_str(), "Hello");
+        assert_eq!(ctx.visibility, GoVisibility::Exported);
+        assert_eq!(ctx.item_type, GoItemType::Function);
+    }
+
+    #[test]
+    fn test_extracts_unexported_function() {
+        let chunker = GoDocChunker::from_config(&test_config()).unwrap();
+        let input = make_input(r#"
+package main
+
+// helper is an internal function.
+func helper() {}
+"#);
+        let chunks = chunker.chunk(&input).unwrap();
+        assert!(!chunks.is_empty());
+        let ctx = match &chunks[0].context {
+            ChunkContext::GoDoc(ctx) => ctx,
+            _ => panic!("Expected GoDoc context"),
+        };
+        assert_eq!(ctx.item_name.to_string().as_str(), "helper");
+        assert_eq!(ctx.visibility, GoVisibility::Unexported);
+    }
+
+    #[test]
+    fn test_extracts_struct_doc() {
+        let chunker = GoDocChunker::from_config(&test_config()).unwrap();
+        let input = make_input(r#"
+package main
+
+// Config holds configuration.
+type Config struct {
+    Name string
+}
+"#);
+        let chunks = chunker.chunk(&input).unwrap();
+        assert!(!chunks.is_empty());
+        let ctx = match &chunks[0].context {
+            ChunkContext::GoDoc(ctx) => ctx,
+            _ => panic!("Expected GoDoc context"),
+        };
+        assert_eq!(ctx.item_name.to_string().as_str(), "Config");
+        assert_eq!(ctx.item_type, GoItemType::Struct);
+    }
+
+    #[test]
+    fn test_skips_undocumented() {
+        let chunker = GoDocChunker::from_config(&test_config()).unwrap();
+        let input = make_input(r#"
+package main
+
+func NoDoc() {}
+"#);
+        let chunks = chunker.chunk(&input).unwrap();
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn test_extracts_package_name() {
+        let chunker = GoDocChunker::from_config(&test_config()).unwrap();
+        let input = make_input(r#"
+package mypackage
+
+// Foo does something.
+func Foo() {}
+"#);
+        let chunks = chunker.chunk(&input).unwrap();
+        assert!(!chunks.is_empty());
+        let ctx = match &chunks[0].context {
+            ChunkContext::GoDoc(ctx) => ctx,
+            _ => panic!("Expected GoDoc context"),
+        };
+        assert_eq!(ctx.package_name.as_ref().map(|p| p.to_string()).as_deref(), Some("mypackage"));
+    }
+}

--- a/crates/crumbly-core/src/knowledge/chunking/mod.rs
+++ b/crates/crumbly-core/src/knowledge/chunking/mod.rs
@@ -1,15 +1,17 @@
 //! Splits documentation files into searchable chunks for semantic indexing.
 //!
-//! Provides strategies for chunking markdown and Rust source files while preserving
+//! Provides strategies for chunking markdown, Rust, and Go source files while preserving
 //! structural context (heading hierarchies, item metadata). Uses token-aware splitting
 //! with configurable overlap to respect embedding model constraints.
 
 pub mod dispatcher;
+pub mod godoc;
 pub mod markdown;
 pub mod rustdoc;
 pub mod strategy;
 
 pub use dispatcher::{ChunkingDispatcher, DispatchError};
+pub use godoc::GoDocChunker;
 pub use markdown::MarkdownChunker;
 pub use rustdoc::RustDocChunker;
 pub use strategy::{ChunkingError, ChunkingInput, ChunkingStrategy};

--- a/crates/crumbly-core/src/knowledge/constants.rs
+++ b/crates/crumbly-core/src/knowledge/constants.rs
@@ -47,6 +47,7 @@ pub const MAX_INDEXING_THREADS: usize = 4;
 
 /// Database schema version for multi-context indexing
 ///
+/// Version 3 adds 'go_doc' to context_type CHECK constraint in chunks table.
 /// Version 2 introduces content-addressed storage with contexts table,
 /// modified indexed_files and chunks tables. Requires rebuild from version 1.
-pub const SCHEMA_VERSION: u32 = 2;
+pub const SCHEMA_VERSION: u32 = 3;

--- a/crates/crumbly-core/src/knowledge/domain/chunk.rs
+++ b/crates/crumbly-core/src/knowledge/domain/chunk.rs
@@ -10,8 +10,8 @@ use bon::Builder;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    ChunkHash, ChunkId, FileHash, HeadingText, IndexRelativePath, ItemName, RepoName, Signature,
-    TokenCount,
+    ChunkHash, ChunkId, FileHash, HeadingText, IndexRelativePath, ItemName, PackageName, RepoName,
+    Signature, TokenCount,
 };
 use crate::knowledge::indexing::RustItemType;
 
@@ -110,7 +110,7 @@ pub struct GoDocContext {
     pub signature: Option<Signature>,
     pub item_type: GoItemType,
     /// Package name for this Go item. None only during parsing errors or malformed files.
-    pub package_name: Option<String>,
+    pub package_name: Option<PackageName>,
 }
 
 /// Visibility of a Go item

--- a/crates/crumbly-core/src/knowledge/domain/chunk.rs
+++ b/crates/crumbly-core/src/knowledge/domain/chunk.rs
@@ -53,6 +53,7 @@ pub struct ChunkContent {
 pub enum ChunkContext {
     Markdown(MarkdownContext),
     RustDoc(RustDocContext),
+    GoDoc(GoDocContext),
 }
 
 /// Heading hierarchy for markdown document structure
@@ -97,4 +98,49 @@ impl From<syn::Visibility> for Visibility {
             syn::Visibility::Inherited => Visibility::Private,
         }
     }
+}
+
+/// Go item metadata for doc comment context
+#[derive(Debug, Clone, PartialEq, Eq, Builder, Serialize, Deserialize)]
+#[builder(on(_, into))]
+#[non_exhaustive]
+pub struct GoDocContext {
+    pub item_name: ItemName,
+    pub visibility: GoVisibility,
+    pub signature: Option<Signature>,
+    pub item_type: GoItemType,
+    /// Package name for this Go item. None only during parsing errors or malformed files.
+    pub package_name: Option<String>,
+}
+
+/// Visibility of a Go item
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GoVisibility {
+    /// Exported (capitalized) item visible outside package
+    Exported,
+    /// Unexported (lowercase) item visible only within package
+    Unexported,
+}
+
+/// Type of Go item
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GoItemType {
+    /// Standalone function
+    Function,
+    /// Method on a type
+    Method,
+    /// Struct type definition
+    Struct,
+    /// Interface type definition
+    Interface,
+    /// Type alias or definition
+    Type,
+    /// Constant declaration
+    Const,
+    /// Variable declaration
+    Var,
+    /// Package-level documentation
+    Package,
 }

--- a/crates/crumbly-core/src/knowledge/domain/file_type.rs
+++ b/crates/crumbly-core/src/knowledge/domain/file_type.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 pub enum FileType {
     Markdown,
     Rust,
+    Go,
     #[serde(skip)]
     Unsupported,
 }
@@ -20,12 +21,13 @@ impl FileType {
         match path.extension().and_then(|s| s.to_str()) {
             Some("md") => Self::Markdown,
             Some("rs") => Self::Rust,
+            Some("go") => Self::Go,
             _ => Self::Unsupported,
         }
     }
 
     pub fn is_indexable(&self) -> bool {
-        matches!(self, Self::Markdown | Self::Rust)
+        matches!(self, Self::Markdown | Self::Rust | Self::Go)
     }
 }
 
@@ -36,6 +38,7 @@ mod test {
 
     #[test_case("README.md", FileType::Markdown, true ; "markdown file")]
     #[test_case("src/main.rs", FileType::Rust, true ; "rust file")]
+    #[test_case("main.go", FileType::Go, true ; "go file")]
     #[test_case("Cargo.toml", FileType::Unsupported, false ; "toml file")]
     #[test_case("LICENSE", FileType::Unsupported, false ; "no extension")]
     fn test_file_classification(path: &str, expected_type: FileType, expected_indexable: bool) {

--- a/crates/crumbly-core/src/knowledge/domain/mod.rs
+++ b/crates/crumbly-core/src/knowledge/domain/mod.rs
@@ -75,6 +75,13 @@ pub struct RepoName(String);
 )]
 pub struct ItemName(String);
 
+/// Name of a Go package
+#[nutype(
+    validate(not_empty),
+    derive(Debug, Clone, Display, Serialize, Deserialize, PartialEq, Eq)
+)]
+pub struct PackageName(String);
+
 /// Markdown heading text for building document hierarchies
 #[nutype(
     validate(not_empty),

--- a/crates/crumbly-core/src/knowledge/domain/mod.rs
+++ b/crates/crumbly-core/src/knowledge/domain/mod.rs
@@ -22,7 +22,8 @@ use uuid::Uuid;
 use crate::knowledge::constants;
 
 pub use chunk::{
-    Chunk, ChunkContent, ChunkContext, ChunkSource, MarkdownContext, RustDocContext, Visibility,
+    Chunk, ChunkContent, ChunkContext, ChunkSource, GoDocContext, GoItemType, GoVisibility,
+    MarkdownContext, RustDocContext, Visibility,
 };
 pub use context::{Context, ContextId, ContextIdError};
 pub use file_type::FileType;

--- a/crates/crumbly-core/src/knowledge/indexing/config.rs
+++ b/crates/crumbly-core/src/knowledge/indexing/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use snafu::{ResultExt, Snafu};
 use std::path::{Path, PathBuf};
 
-use super::filter::{IndexingFilter, RustFilter, RustItemType};
+use super::filter::{GoFilter, GoItemType, IndexingFilter, RustFilter, RustItemType};
 use crate::knowledge::constants::SEMBLY_CONFIG;
 use crate::knowledge::domain::{FileType, Visibility};
 use crate::knowledge::scoring::BoostRule;
@@ -47,9 +47,16 @@ impl CrumblyConfig {
             None
         };
 
+        let go_filter = if self.enabled_file_types.contains(&FileType::Go) {
+            Some(self.file_types.go.to_go_filter()?)
+        } else {
+            None
+        };
+
         Ok(IndexingFilter::new(
             self.enabled_file_types.clone(),
             rust_filter,
+            go_filter,
         ))
     }
 }
@@ -72,6 +79,10 @@ pub struct FileTypeConfig {
     /// Rust-specific indexing controls
     #[serde(default)]
     pub rust: RustConfig,
+
+    /// Go-specific indexing controls
+    #[serde(default)]
+    pub go: GoConfig,
 }
 
 /// Configuration for indexing Rust source files
@@ -84,7 +95,7 @@ pub struct RustConfig {
 
     /// Item types to index ("all" or specific types)
     #[serde(default = "default_rust_items", deserialize_with = "deserialize_items")]
-    items: Vec<RustItemType>,
+    pub items: Vec<RustItemType>,
 
     /// Minimum doc comment length in lines
     #[serde(default)]
@@ -140,12 +151,66 @@ impl Default for RustConfig {
     }
 }
 
+/// Configuration for indexing Go source files
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct GoConfig {
+    /// Visibility levels to index
+    #[serde(default = "default_visibility")]
+    pub visibility: Vec<Visibility>,
+
+    /// Item types to index
+    #[serde(default = "default_go_items")]
+    pub items: Vec<GoItemType>,
+
+    /// Minimum doc comment length in lines
+    #[serde(default)]
+    pub min_doc_lines: usize,
+}
+
+impl GoConfig {
+    /// Convert to a GoFilter for use during indexing
+    fn to_go_filter(&self) -> Result<GoFilter, CrumblyConfigError> {
+        Ok(GoFilter::new(
+            self.visibility.clone(),
+            self.items.clone(),
+            self.min_doc_lines,
+        ))
+    }
+}
+
+impl Default for GoConfig {
+    fn default() -> Self {
+        Self {
+            visibility: default_visibility(),
+            items: default_go_items(),
+            min_doc_lines: 0,
+        }
+    }
+}
+
 fn default_file_types() -> Vec<FileType> {
     vec![FileType::Markdown, FileType::Rust]
 }
 
 fn default_rust_visibility() -> Vec<Visibility> {
     vec![Visibility::Public]
+}
+
+fn default_visibility() -> Vec<Visibility> {
+    vec![Visibility::Public]
+}
+
+fn default_go_items() -> Vec<GoItemType> {
+    vec![
+        GoItemType::Function,
+        GoItemType::Method,
+        GoItemType::Struct,
+        GoItemType::Interface,
+        GoItemType::Type,
+        GoItemType::Const,
+        GoItemType::Var,
+    ]
 }
 
 fn default_rust_items() -> Vec<RustItemType> {
@@ -188,6 +253,9 @@ pub fn load_crumbly_config(
         path: index_root.display().to_string(),
     })?;
 
+    // Best-effort validation to catch user errors in configuration.
+    // TOCTOU: Paths could change between validation and use, but this is not a
+    // security boundary - it's a developer tool running with user's permissions.
     for target in &config.targets {
         if target.is_absolute() {
             return Err(CrumblyConfigError::InvalidPath {
@@ -395,6 +463,7 @@ min-doc-lines = 30
                     items: vec![RustItemType::Struct],
                     min_doc_lines: 20,
                 },
+                go: GoConfig::default(),
             },
             boost_rules: vec![],
         };

--- a/crates/crumbly-core/src/knowledge/indexing/filter.rs
+++ b/crates/crumbly-core/src/knowledge/indexing/filter.rs
@@ -13,22 +13,33 @@ use crate::knowledge::domain::Visibility;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RustItemType {
-    #[serde(rename = "modules")]
     Module,
-    #[serde(rename = "functions")]
     Function,
-    #[serde(rename = "structs")]
     Struct,
-    #[serde(rename = "enums")]
     Enum,
-    #[serde(rename = "traits")]
     Trait,
-    #[serde(rename = "impls")]
     Impl,
-    #[serde(rename = "type-aliases")]
     TypeAlias,
-    #[serde(rename = "constants")]
     Constant,
+}
+
+/// Categories of Go language items that can be filtered during indexing
+///
+/// Unlike RustItemType, includes an `All` variant for convenience in configuration.
+/// This allows `items = ["all"]` in config rather than listing all types explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GoItemType {
+    All,
+    Function,
+    Method,
+    Struct,
+    Interface,
+    Type,
+    #[serde(rename = "constants")]
+    Const,
+    #[serde(rename = "variables")]
+    Var,
 }
 
 /// Filtering rules for Rust source code indexing
@@ -60,19 +71,44 @@ impl RustFilter {
         item_type: &RustItemType,
         doc_lines: usize,
     ) -> bool {
-        if doc_lines < self.min_doc_lines {
-            return false;
-        }
+        doc_lines >= self.min_doc_lines
+            && self.visibility.contains(visibility)
+            && self.items.contains(item_type)
+    }
+}
 
-        if !self.visibility.contains(visibility) {
-            return false;
-        }
+/// Filtering rules for Go source code indexing
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoFilter {
+    visibility: Vec<Visibility>,
+    items: Vec<GoItemType>,
+    min_doc_lines: usize,
+}
 
-        if !self.items.contains(item_type) {
-            return false;
+impl GoFilter {
+    /// Create a filter with visibility, item types, and minimum documentation length
+    pub fn new(
+        visibility: Vec<Visibility>,
+        items: Vec<GoItemType>,
+        min_doc_lines: usize,
+    ) -> Self {
+        Self {
+            visibility,
+            items,
+            min_doc_lines,
         }
+    }
 
-        true
+    /// Determine whether a Go item should be indexed based on filter criteria
+    pub fn should_index(
+        &self,
+        visibility: &Visibility,
+        item_type: &GoItemType,
+        doc_lines: usize,
+    ) -> bool {
+        doc_lines >= self.min_doc_lines
+            && self.visibility.contains(visibility)
+            && (self.items.contains(&GoItemType::All) || self.items.contains(item_type))
     }
 }
 
@@ -81,17 +117,20 @@ impl RustFilter {
 pub struct IndexingFilter {
     enabled_file_types: Vec<crate::knowledge::domain::FileType>,
     rust_filter: Option<RustFilter>,
+    go_filter: Option<GoFilter>,
 }
 
 impl IndexingFilter {
-    /// Create a filter with enabled file types and optional Rust-specific rules
+    /// Create a filter with enabled file types and optional language-specific rules
     pub fn new(
         enabled_file_types: Vec<crate::knowledge::domain::FileType>,
         rust_filter: Option<RustFilter>,
+        go_filter: Option<GoFilter>,
     ) -> Self {
         Self {
             enabled_file_types,
             rust_filter,
+            go_filter,
         }
     }
 
@@ -103,6 +142,11 @@ impl IndexingFilter {
     /// Access the Rust-specific filter if configured
     pub fn rust_filter(&self) -> Option<&RustFilter> {
         self.rust_filter.as_ref()
+    }
+
+    /// Access the Go-specific filter if configured
+    pub fn go_filter(&self) -> Option<&GoFilter> {
+        self.go_filter.as_ref()
     }
 }
 
@@ -123,6 +167,19 @@ impl Default for IndexingFilter {
                     RustItemType::Impl,
                     RustItemType::TypeAlias,
                     RustItemType::Constant,
+                ],
+                0,
+            )),
+            go_filter: Some(GoFilter::new(
+                vec![Visibility::Public, Visibility::Private],
+                vec![
+                    GoItemType::Function,
+                    GoItemType::Method,
+                    GoItemType::Struct,
+                    GoItemType::Interface,
+                    GoItemType::Type,
+                    GoItemType::Const,
+                    GoItemType::Var,
                 ],
                 0,
             )),
@@ -180,7 +237,7 @@ mod test {
     fn test_indexing_filter_should_index_file_type() {
         // Given A filter with only markdown enabled
         use crate::knowledge::domain::FileType;
-        let filter = IndexingFilter::new(vec![FileType::Markdown], None);
+        let filter = IndexingFilter::new(vec![FileType::Markdown], None, None);
 
         // When Checking different file types
         let markdown = filter.should_index_file_type(FileType::Markdown);
@@ -195,7 +252,7 @@ mod test {
     fn test_indexing_filter_rust_filter_returns_reference() {
         // Given A filter with Rust filter configured
         let rust_filter = RustFilter::new(vec![Visibility::Public], vec![], 0);
-        let filter = IndexingFilter::new(vec![], Some(rust_filter));
+        let filter = IndexingFilter::new(vec![], Some(rust_filter), None);
 
         // When Getting the Rust filter
         let result = filter.rust_filter();
@@ -204,3 +261,30 @@ mod test {
         assert!(result.is_some());
     }
 }
+
+    #[test]
+    fn test_go_filter_should_index_checks_doc_lines() {
+        let filter = GoFilter::new(vec![Visibility::Public], vec![GoItemType::Function], 3);
+        let short_doc = filter.should_index(&Visibility::Public, &GoItemType::Function, 2);
+        let long_doc = filter.should_index(&Visibility::Public, &GoItemType::Function, 5);
+        assert!(!short_doc);
+        assert!(long_doc);
+    }
+
+    #[test]
+    fn test_go_filter_should_index_checks_visibility() {
+        let filter = GoFilter::new(vec![Visibility::Public], vec![GoItemType::Function], 0);
+        let public = filter.should_index(&Visibility::Public, &GoItemType::Function, 100);
+        let private = filter.should_index(&Visibility::Private, &GoItemType::Function, 100);
+        assert!(public);
+        assert!(!private);
+    }
+
+    #[test]
+    fn test_go_filter_should_index_checks_item_type() {
+        let filter = GoFilter::new(vec![Visibility::Public], vec![GoItemType::Struct], 0);
+        let struct_item = filter.should_index(&Visibility::Public, &GoItemType::Struct, 100);
+        let function_item = filter.should_index(&Visibility::Public, &GoItemType::Function, 100);
+        assert!(struct_item);
+        assert!(!function_item);
+    }

--- a/crates/crumbly-core/src/knowledge/indexing/filter.rs
+++ b/crates/crumbly-core/src/knowledge/indexing/filter.rs
@@ -13,13 +13,21 @@ use crate::knowledge::domain::Visibility;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RustItemType {
+    #[serde(rename = "modules")]
     Module,
+    #[serde(rename = "functions")]
     Function,
+    #[serde(rename = "structs")]
     Struct,
+    #[serde(rename = "enums")]
     Enum,
+    #[serde(rename = "traits")]
     Trait,
+    #[serde(rename = "impls")]
     Impl,
+    #[serde(rename = "type-aliases")]
     TypeAlias,
+    #[serde(rename = "constants")]
     Constant,
 }
 
@@ -31,10 +39,15 @@ pub enum RustItemType {
 #[serde(rename_all = "kebab-case")]
 pub enum GoItemType {
     All,
+    #[serde(rename = "functions")]
     Function,
+    #[serde(rename = "methods")]
     Method,
+    #[serde(rename = "structs")]
     Struct,
+    #[serde(rename = "interfaces")]
     Interface,
+    #[serde(rename = "types")]
     Type,
     #[serde(rename = "constants")]
     Const,

--- a/crates/crumbly-core/src/knowledge/indexing/mod.rs
+++ b/crates/crumbly-core/src/knowledge/indexing/mod.rs
@@ -37,7 +37,7 @@ pub mod provider;
 pub mod scanner;
 
 pub use config::{CrumblyConfig, CrumblyConfigError, load_crumbly_config};
-pub use filter::{IndexingFilter, RustFilter, RustItemType};
+pub use filter::{GoFilter, GoItemType, IndexingFilter, RustFilter, RustItemType};
 pub use indexer::{BatchConfig, IndexResult, IndexStrategy, Indexer, IndexingError};
 pub use progress::{ProgressReporter, SilentReporter};
 pub use provider::{IndexDataError, IndexDataProvider};

--- a/crates/crumbly-core/src/knowledge/storage/schema.rs
+++ b/crates/crumbly-core/src/knowledge/storage/schema.rs
@@ -59,6 +59,19 @@ CREATE TABLE IF NOT EXISTS chunks (
     chunk_hash BLOB PRIMARY KEY,
     file_hash BLOB NOT NULL,
     repo_name TEXT NOT NULL,
+    context_type TEXT NOT NULL CHECK(context_type IN ('markdown', 'rust_doc', 'go_doc')),
+    context_data TEXT NOT NULL,
+    content TEXT NOT NULL,
+    token_count INTEGER NOT NULL,
+    last_modified INTEGER NOT NULL
+)
+"#;
+
+const CREATE_CHUNKS_V2: &str = r#"
+CREATE TABLE IF NOT EXISTS chunks (
+    chunk_hash BLOB PRIMARY KEY,
+    file_hash BLOB NOT NULL,
+    repo_name TEXT NOT NULL,
     context_type TEXT NOT NULL CHECK(context_type IN ('markdown', 'rust_doc')),
     context_data TEXT NOT NULL,
     content TEXT NOT NULL,
@@ -70,6 +83,8 @@ CREATE TABLE IF NOT EXISTS chunks (
 const CREATE_INDEX_FILE_HASH: &str =
     "CREATE INDEX IF NOT EXISTS idx_chunks_file_hash ON chunks(file_hash)";
 const CREATE_INDEX_REPO: &str = "CREATE INDEX IF NOT EXISTS idx_chunks_repo ON chunks(repo_name)";
+const CREATE_INDEX_CONTEXT_TYPE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_chunks_context_type ON chunks(context_type)";
 
 /// Reads the schema version from the index_metadata table
 ///
@@ -103,20 +118,24 @@ pub fn set_schema_version(conn: &Connection, version: u32) -> Result<()> {
 
 /// Validates that the stored schema version matches the expected version
 ///
-/// Returns an error if the versions do not match, indicating the index
-/// needs to be rebuilt.
+/// Attempts migration if possible, otherwise returns an error indicating
+/// the index needs to be rebuilt.
 pub fn check_schema_version(conn: &Connection) -> Result<()> {
     use schema_error::*;
 
     let stored = get_schema_version(conn)?.unwrap_or(0);
-    if stored != SCHEMA_VERSION {
-        return SchemaMismatchSnafu {
+    if stored == SCHEMA_VERSION {
+        return Ok(());
+    }
+
+    match (stored, SCHEMA_VERSION) {
+        (2, 3) => migrate_v2_to_v3(conn),
+        _ => SchemaMismatchSnafu {
             stored,
             expected: SCHEMA_VERSION,
         }
-        .fail();
+        .fail(),
     }
-    Ok(())
 }
 
 /// Initializes database schema including tables and indexes
@@ -134,6 +153,8 @@ pub fn create_tables(conn: &Connection, config: &EmbeddingModelConfig) -> Result
         .context(SqlExecutionSnafu)?;
     conn.execute(CREATE_INDEX_REPO, [])
         .context(SqlExecutionSnafu)?;
+    conn.execute(CREATE_INDEX_CONTEXT_TYPE, [])
+        .context(SqlExecutionSnafu)?;
 
     let create_vec_chunks = format!(
         "CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(
@@ -150,7 +171,65 @@ pub fn create_tables(conn: &Connection, config: &EmbeddingModelConfig) -> Result
     Ok(())
 }
 
+/// Migrates from schema v2 to v3
+///
+/// v3 adds 'go_doc' to the context_type CHECK constraint in chunks table.
+fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
+    use schema_error::*;
+
+    conn.execute("BEGIN TRANSACTION", []).context(SqlExecutionSnafu)?;
+
+    let result = (|| -> Result<()> {
+        conn.execute(
+            r#"CREATE TABLE chunks_new (
+    chunk_hash BLOB PRIMARY KEY,
+    file_hash BLOB NOT NULL,
+    repo_name TEXT NOT NULL,
+    context_type TEXT NOT NULL CHECK(context_type IN ('markdown', 'rust_doc', 'go_doc')),
+    context_data TEXT NOT NULL,
+    content TEXT NOT NULL,
+    token_count INTEGER NOT NULL,
+    last_modified INTEGER NOT NULL
+)"#,
+            [],
+        ).context(SqlExecutionSnafu)?;
+
+        conn.execute("INSERT INTO chunks_new SELECT * FROM chunks", [])
+            .context(SqlExecutionSnafu)?;
+
+        conn.execute("DROP TABLE chunks", []).context(SqlExecutionSnafu)?;
+
+        conn.execute("ALTER TABLE chunks_new RENAME TO chunks", [])
+            .context(SqlExecutionSnafu)?;
+
+        conn.execute(CREATE_INDEX_FILE_HASH, []).context(SqlExecutionSnafu)?;
+        conn.execute(CREATE_INDEX_REPO, []).context(SqlExecutionSnafu)?;
+        conn.execute(CREATE_INDEX_CONTEXT_TYPE, []).context(SqlExecutionSnafu)?;
+
+        set_schema_version(conn, 3)?;
+
+        Ok(())
+    })();
+
+    match result {
+        Ok(_) => {
+            conn.execute("COMMIT", []).context(SqlExecutionSnafu)?;
+            Ok(())
+        }
+        Err(e) => {
+            if let Err(rollback_err) = conn.execute("ROLLBACK", []) {
+                eprintln!("Warning: Failed to rollback transaction: {}", rollback_err);
+            }
+            Err(e)
+        }
+    }
+}
+
 /// Applies database migrations for schema evolution
+///
+/// Reserved for future migrations. Currently migrations are handled
+/// automatically by check_schema_version() when opening a database.
+#[allow(dead_code)]
 pub fn migrate(_conn: &Connection) -> Result<()> {
     Ok(())
 }
@@ -399,5 +478,53 @@ mod test {
         // Then the schema version should be set to SCHEMA_VERSION
         let version = get_schema_version(&conn).unwrap();
         assert_eq!(version, Some(SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn test_migrate_v2_to_v3() {
+        let conn = setup_connection();
+        
+        conn.execute(CREATE_INDEX_METADATA, []).unwrap();
+        conn.execute(CREATE_CHUNKS_V2, []).unwrap();
+        conn.execute(CREATE_INDEX_FILE_HASH, []).unwrap();
+        conn.execute(CREATE_INDEX_REPO, []).unwrap();
+        
+        set_schema_version(&conn, 2).unwrap();
+        
+        conn.execute(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rusqlite::params![
+                &[1u8, 2, 3][..],
+                &[4u8, 5, 6][..],
+                "test-repo",
+                "markdown",
+                "{}",
+                "test content",
+                10,
+                1234567890
+            ],
+        ).unwrap();
+        
+        check_schema_version(&conn).unwrap();
+        
+        let version = get_schema_version(&conn).unwrap();
+        assert_eq!(version, Some(3));
+        
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 1);
+        
+        conn.execute(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rusqlite::params![
+                &[7u8, 8, 9][..],
+                &[10u8, 11, 12][..],
+                "test-repo",
+                "go_doc",
+                "{}",
+                "go content",
+                15,
+                1234567891
+            ],
+        ).unwrap();
     }
 }

--- a/crates/crumbly-core/src/knowledge/storage/sqlite/chunks.rs
+++ b/crates/crumbly-core/src/knowledge/storage/sqlite/chunks.rs
@@ -6,259 +6,70 @@
 //! which context it appears in.
 
 use rusqlite::Connection;
-use snafu::{ResultExt, Snafu};
+use snafu::ResultExt;
 
-use crate::knowledge::constants::EMBEDDING_DIM;
-use crate::knowledge::domain::{
-    Chunk, ChunkContent, ChunkContext, ChunkHash, ChunkId, ChunkSource, Embedding, FileHash,
-    IndexRelativePath, IndexedChunk, MarkdownContext, RepoName, RustDocContext, Timestamp,
-    TokenCount,
-};
+use crate::knowledge::domain::{ChunkHash, FileHash, IndexedChunk};
+use crate::knowledge::storage::repository::{StorageError, storage_error::*};
+use super::serialization::{indexed_chunk_from_row, serialize_context};
 
-/// Errors that can occur during chunk storage operations.
-#[derive(Debug, Snafu)]
-#[snafu(module, visibility(pub))]
-#[non_exhaustive]
-pub enum ChunkStorageError {
-    /// Database operation failed.
-    #[snafu(display("Database operation failed"))]
-    Database { source: rusqlite::Error },
-
-    /// Invalid data retrieved from database.
-    #[snafu(display("Invalid data in database: {message}"))]
-    InvalidData { message: String },
+pub fn save_chunk(conn: &Connection, chunk: &IndexedChunk) -> Result<(), StorageError> {
+  let (context_type, context_data) = serialize_context(&chunk.chunk.context)?;
+  conn.execute(
+    "INSERT OR REPLACE INTO chunks 
+    (chunk_hash, file_hash, repo_name, context_type, context_data, content, token_count, last_modified)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+    rusqlite::params![
+      chunk.chunk.chunk_hash.as_bytes(),
+      chunk.chunk.file_hash.as_bytes(),
+      chunk.chunk.source.repo_name.to_string(),
+      context_type,
+      context_data,
+      chunk.chunk.content.text,
+      chunk.chunk.content.token_count.into_inner() as i64,
+      chunk.indexed_at.as_secs(),
+    ],
+  ).context(DatabaseSnafu)?;
+  Ok(())
 }
 
-/// Converts a domain error into ChunkStorageError with a custom message.
-fn to_invalid_data<E>(message: &str) -> impl FnOnce(E) -> ChunkStorageError + '_
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    move |_| {
-        chunk_storage_error::InvalidDataSnafu {
-            message: message.to_string(),
-        }
-        .build()
-    }
-}
-
-/// Reconstructs an IndexedChunk from a database row with the new schema.
-///
-/// Expects columns: chunk_hash, file_hash, repo_name, context_type, context_data,
-/// content, token_count, last_modified.
-fn indexed_chunk_from_row(row: &rusqlite::Row) -> Result<IndexedChunk, ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    let chunk_hash_bytes: Vec<u8> = row.get(0).context(DatabaseSnafu)?;
-    let file_hash_bytes: Vec<u8> = row.get(1).context(DatabaseSnafu)?;
-    let repo_name: String = row.get(2).context(DatabaseSnafu)?;
-    let context_type: String = row.get(3).context(DatabaseSnafu)?;
-    let context_data: String = row.get(4).context(DatabaseSnafu)?;
-    let content: String = row.get(5).context(DatabaseSnafu)?;
-    let token_count: i64 = row.get(6).context(DatabaseSnafu)?;
-    let last_modified: i64 = row.get(7).context(DatabaseSnafu)?;
-
-    let chunk_hash_array: [u8; 32] = chunk_hash_bytes.try_into().map_err(|_| {
-        InvalidDataSnafu {
-            message: "chunk_hash must be 32 bytes".to_string(),
-        }
-        .build()
-    })?;
-
-    let file_hash_array: [u8; 32] = file_hash_bytes.try_into().map_err(|_| {
-        InvalidDataSnafu {
-            message: "file_hash must be 32 bytes".to_string(),
-        }
-        .build()
-    })?;
-
-    let context = deserialize_context(&context_type, &context_data)?;
-
-    let embedding = Embedding::try_new(vec![0.1; EMBEDDING_DIM])
-        .map_err(to_invalid_data("failed to create dummy embedding"))?;
-
-    let chunk = Chunk::builder()
-        .id(ChunkId::new(uuid::Uuid::new_v4()))
-        .chunk_hash(ChunkHash::new(chunk_hash_array))
-        .file_hash(FileHash::new(file_hash_array))
-        .source(
-            ChunkSource::builder()
-                .file_path(
-                    IndexRelativePath::try_new("unknown.md")
-                        .map_err(to_invalid_data("failed to create file path"))?,
-                )
-                .repo_name(
-                    RepoName::try_new(repo_name).map_err(to_invalid_data("invalid repo_name"))?,
-                )
-                .build(),
-        )
-        .content(
-            ChunkContent::builder()
-                .text(content)
-                .token_count(
-                    TokenCount::try_new(token_count as usize)
-                        .map_err(to_invalid_data("invalid token_count"))?,
-                )
-                .build(),
-        )
-        .context(context)
-        .build();
-
-    Ok(IndexedChunk::builder()
-        .chunk(chunk)
-        .embedding(embedding)
-        .indexed_at(Timestamp::from_secs(last_modified))
-        .build())
-}
-
-/// Converts ChunkContext to database-storable type and JSON representation
-fn serialize_context(context: &ChunkContext) -> Result<(String, String), ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    let (context_type, context_data) = match context {
-        ChunkContext::Markdown(ctx) => (
-            "markdown",
-            serde_json::to_string(ctx).map_err(|e| {
-                InvalidDataSnafu {
-                    message: e.to_string(),
-                }
-                .build()
-            })?,
-        ),
-        ChunkContext::RustDoc(ctx) => (
-            "rust_doc",
-            serde_json::to_string(ctx).map_err(|e| {
-                InvalidDataSnafu {
-                    message: e.to_string(),
-                }
-                .build()
-            })?,
-        ),
-    };
-
-    Ok((context_type.to_string(), context_data))
-}
-
-/// Reconstructs ChunkContext from database type and JSON fields
-fn deserialize_context(
-    context_type: &str,
-    context_data: &str,
-) -> Result<ChunkContext, ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    match context_type {
-        "markdown" => {
-            let ctx: MarkdownContext = serde_json::from_str(context_data).map_err(|e| {
-                InvalidDataSnafu {
-                    message: e.to_string(),
-                }
-                .build()
-            })?;
-            Ok(ChunkContext::Markdown(ctx))
-        }
-        "rust_doc" => {
-            let ctx: RustDocContext = serde_json::from_str(context_data).map_err(|e| {
-                InvalidDataSnafu {
-                    message: e.to_string(),
-                }
-                .build()
-            })?;
-            Ok(ChunkContext::RustDoc(ctx))
-        }
-        _ => Err(InvalidDataSnafu {
-            message: format!("unknown context type: {}", context_type),
-        }
-        .build()),
-    }
-}
-
-/// Saves a chunk to storage (idempotent - handles UNIQUE constraint).
-pub fn save_chunk(conn: &Connection, chunk: &IndexedChunk) -> Result<(), ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    let (context_type, context_data) = serialize_context(&chunk.chunk.context)?;
-
-    conn.execute(
-        "INSERT OR REPLACE INTO chunks 
-        (chunk_hash, file_hash, repo_name, context_type, context_data, content, token_count, last_modified)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-        rusqlite::params![
-            chunk.chunk.chunk_hash.as_bytes(),
-            chunk.chunk.file_hash.as_bytes(),
-            chunk.chunk.source.repo_name.to_string(),
-            context_type,
-            context_data,
-            chunk.chunk.content.text,
-            chunk.chunk.content.token_count.into_inner() as i64,
-            chunk.indexed_at.as_secs(),
-        ],
-    )
-    .context(DatabaseSnafu)?;
-
-    Ok(())
-}
-
-/// Retrieves all chunks associated with a file hash.
 pub fn get_chunks_by_file_hash(
-    conn: &Connection,
-    file_hash: &FileHash,
-) -> Result<Vec<IndexedChunk>, ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT chunk_hash, file_hash, repo_name, context_type, context_data, 
-                    content, token_count, last_modified
-             FROM chunks
-             WHERE file_hash = ?1",
-        )
-        .context(DatabaseSnafu)?;
-
-    stmt.query_map([file_hash.as_bytes()], |row| {
-        indexed_chunk_from_row(row)
-            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
-    })
-    .context(DatabaseSnafu)?
-    .collect::<Result<Vec<_>, _>>()
-    .context(DatabaseSnafu)
+  conn: &Connection,
+  file_hash: &FileHash,
+) -> Result<Vec<IndexedChunk>, StorageError> {
+  let mut stmt = conn.prepare(
+    "SELECT chunk_hash, chunk_hash, file_hash, '', repo_name, context_type, context_data, 
+            content, token_count, last_modified
+     FROM chunks
+     WHERE file_hash = ?1",
+  ).context(DatabaseSnafu)?;
+  stmt.query_map([file_hash.as_bytes()], |row| {
+    indexed_chunk_from_row(row)
+      .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+  })
+  .context(DatabaseSnafu)?
+  .collect::<Result<Vec<_>, _>>()
+  .context(DatabaseSnafu)
 }
 
-/// Checks if a chunk with the given hash exists.
-pub fn has_chunk(conn: &Connection, chunk_hash: &ChunkHash) -> Result<bool, ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM chunks WHERE chunk_hash = ?1",
-            [chunk_hash.as_bytes()],
-            |row| row.get(0),
-        )
-        .context(DatabaseSnafu)?;
-
-    Ok(count > 0)
+pub fn has_chunk(conn: &Connection, chunk_hash: &ChunkHash) -> Result<bool, StorageError> {
+  let count: i64 = conn.query_row(
+    "SELECT COUNT(*) FROM chunks WHERE chunk_hash = ?1",
+    [chunk_hash.as_bytes()],
+    |row| row.get(0),
+  ).context(DatabaseSnafu)?;
+  Ok(count > 0)
 }
 
-/// Deletes chunks not referenced by any context's indexed files.
-///
-/// Removes orphaned chunks whose file_hash is not present in the indexed_files table.
-/// Also removes associated embeddings. Returns the count of deleted chunks.
-pub fn delete_orphaned_chunks(conn: &Connection) -> Result<u64, ChunkStorageError> {
-    use chunk_storage_error::*;
-
-    let deleted_chunks = conn
-        .execute(
-            "DELETE FROM chunks WHERE file_hash NOT IN (SELECT DISTINCT file_hash FROM indexed_files)",
-            [],
-        )
-        .context(DatabaseSnafu)?;
-
-    conn.execute(
-        "DELETE FROM vec_chunks WHERE chunk_hash NOT IN (SELECT chunk_hash FROM chunks)",
-        [],
-    )
-    .context(DatabaseSnafu)?;
-
-    Ok(deleted_chunks as u64)
+pub fn delete_orphaned_chunks(conn: &Connection) -> Result<u64, StorageError> {
+  let deleted_chunks = conn.execute(
+    "DELETE FROM chunks WHERE file_hash NOT IN (SELECT DISTINCT file_hash FROM indexed_files)",
+    [],
+  ).context(DatabaseSnafu)?;
+  conn.execute(
+    "DELETE FROM vec_chunks WHERE chunk_hash NOT IN (SELECT chunk_hash FROM chunks)",
+    [],
+  ).context(DatabaseSnafu)?;
+  Ok(deleted_chunks as u64)
 }
 
 #[cfg(test)]

--- a/crates/crumbly-core/src/knowledge/storage/sqlite/mod.rs
+++ b/crates/crumbly-core/src/knowledge/storage/sqlite/mod.rs
@@ -242,14 +242,7 @@ impl ChunkRepository for SqliteChunkRepository {
     }
 
     fn delete_orphaned_chunks(&mut self) -> Result<u64, StorageError> {
-        chunks::delete_orphaned_chunks(&self.conn).map_err(|e| StorageError::DatabaseError {
-            source: match e {
-                chunks::ChunkStorageError::Database { source } => source,
-                chunks::ChunkStorageError::InvalidData { message: _ } => {
-                    rusqlite::Error::InvalidQuery
-                }
-            },
-        })
+        chunks::delete_orphaned_chunks(&self.conn)
     }
 
     fn clear_context_files(&mut self, context_id: &ContextId) -> Result<usize, StorageError> {

--- a/crates/crumbly-core/src/knowledge/storage/sqlite/serialization.rs
+++ b/crates/crumbly-core/src/knowledge/storage/sqlite/serialization.rs
@@ -6,10 +6,13 @@
 use snafu::ResultExt;
 
 use crate::knowledge::constants::EMBEDDING_DIM;
+
+const UUID_BYTE_LENGTH: usize = 16;
+use crate::knowledge::domain::chunk::GoDocContext;
 use crate::knowledge::domain::{
     Chunk, ChunkContent, ChunkContext, ChunkHash, ChunkId, ChunkSource, Embedding, FileHash,
-    IndexRelativePath, IndexedChunk, MarkdownContext, RepoName, RustDocContext, Timestamp,
-    TokenCount,
+    IndexRelativePath, IndexedChunk, MarkdownContext, RepoName, RustDocContext,
+    Timestamp, TokenCount,
 };
 use crate::knowledge::storage::repository::{StorageError, storage_error::*};
 
@@ -47,9 +50,9 @@ pub fn indexed_chunk_from_row(row: &rusqlite::Row) -> Result<IndexedChunk, Stora
     let last_modified: i64 = row.get(9).context(DatabaseSnafu)?;
 
     // Generate a deterministic UUID from the chunk_hash bytes
-    let uuid = if chunk_hash_for_id.len() >= 16 {
-        let mut bytes = [0u8; 16];
-        bytes.copy_from_slice(&chunk_hash_for_id[..16]);
+    let uuid = if chunk_hash_for_id.len() >= UUID_BYTE_LENGTH {
+        let mut bytes = [0u8; UUID_BYTE_LENGTH];
+        bytes.copy_from_slice(&chunk_hash_for_id[..UUID_BYTE_LENGTH]);
         uuid::Uuid::from_bytes(bytes)
     } else {
         uuid::Uuid::nil()
@@ -144,6 +147,15 @@ pub fn serialize_context(context: &ChunkContext) -> Result<(String, String), Sto
                 .build()
             })?,
         ),
+        ChunkContext::GoDoc(ctx) => (
+            "go_doc",
+            serde_json::to_string(ctx).map_err(|e| {
+                InvalidDataSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?,
+        ),
     };
 
     Ok((context_type.to_string(), context_data))
@@ -164,6 +176,11 @@ pub fn deserialize_context(
             let ctx: RustDocContext =
                 serde_json::from_str(context_data).context(SerializationSnafu)?;
             Ok(ChunkContext::RustDoc(ctx))
+        }
+        "go_doc" => {
+            let ctx: GoDocContext =
+                serde_json::from_str(context_data).context(SerializationSnafu)?;
+            Ok(ChunkContext::GoDoc(ctx))
         }
         _ => Err(InvalidDataSnafu {
             message: format!("unknown context type: {}", context_type),


### PR DESCRIPTION
## Description of changes

This PR adds support for indexing Go source files in crumbly, enabling semantic search over Go documentation comments. The implementation uses [tree-sitter](https://tree-sitter.github.io/tree-sitter/) for AST parsing and follows the same patterns established by the existing Rust documentation chunker.

I've been working on building a kubernetes-forest for exploring some issues with Bottlerocket + k8s networking and these changes helped tremendously in indexing Go code across k8s, cni, etcd, and calico trees in the forest.

### Code changes

#### Commits

1. **feat(domain): add Go domain types**
   - Add `Go` variant to `FileType` enum
   - Add `GoDocContext` for Go documentation chunks
   - Add `GoVisibility` enum (Exported, Unexported)
   - Add `GoItemType` enum (Function, Method, Type, Struct, Interface, Const, Var, Package)

2. **feat(schema): add schema support for Go documentation**
   - Bump `SCHEMA_VERSION` to 3
   - Add `go_doc` to `context_type` CHECK constraint
   - Implement `migrate_v2_to_v3()` for automatic migration
   - Add serialization/deserialization for `GoDocContext`

3. **feat(config): add Go configuration and filtering**
   - Add `GoConfig` for `crumbly.toml` `[file-types.go]` section
   - Add `GoFilter` and `GoFilterItemType` for filtering Go items
   - Support visibility and item type filtering

4. **feat(chunking): implement GoDocChunker with tree-sitter**
   - Add `tree-sitter` and `tree-sitter-go` dependencies
   - Create `GoDocChunker` for parsing Go source files
   - Extract documentation from functions, methods, types, consts, vars
   - Register `GoDocChunker` in dispatcher


### Configuration changes

Users can enable Go file indexing in `crumbly.toml`:

```toml
enabled-file-types = ["markdown", "rust", "go"]

[file-types.go]
visibility = ["public"]      # or ["public", "private"] for all
items = ["all"]              # or specific: ["functions", "methods", "structs"]
min-doc-lines = 0
```

### Schema Migration

- Existing v2 databases are automatically migrated to v3 on first access
- Migration adds `go_doc` to the `context_type` CHECK constraint
- No data loss; existing chunks are preserved



### Tree-sitter Usage

Unlike the Rust chunker (which uses `syn`), the Go chunker uses tree-sitter for parsing:
- More manual tree traversal required
- Node kind constants defined to avoid string typos
- Handles nested `type_spec` nodes for struct/interface detection

### Filter Deduplication

Added `should_index()` helper method to reduce filter checking duplication from 5 places to 1.


### Testing

- 6 new unit tests for `GoDocChunker`:
  - `test_supports_go_files` - file extension detection
  - `test_extracts_function_doc` - exported function documentation
  - `test_extracts_unexported_function` - unexported function handling
  - `test_extracts_struct_doc` - struct type documentation
  - `test_skips_undocumented` - skips items without doc comments
  - `test_extracts_package_name` - package name in context

- All 331 existing `crumbly-core` tests continue to pass

On my kubernetes-forest, with the following in crumbly.toml:

```toml
[file-types.go]
visibility = ["public"]
items = ["structs", "interfaces", "types"]
min-doc-lines = 0
```

I see the following index results after a `crumbly build`:

```bash
$ sqlite3 .crumbly/knowledge.db "SELECT context_type, COUNT(*) FROM chunks GROUP BY context_type"
go_doc|13598
markdown|28978
```

