### PR TITLE
docs: fix forester section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,20 @@ Crumbly is a standalone open-source tool that can be applied to any codebase.
 
 Generic forest management tool. **Must run from forest root directory.**
 
+Install via:
 ```bash
-brdev registry start    # Start local registry
-brdev registry status   # Check registry status
-brdev registry list     # List published images
+cargo install forester
 ```
 
-See `crates/forester/README.md` for complete documentation.
+Usage:
+```bash
+forester seed                        # Clone all member repos and set up forest
+forester worktree create feature-x   # Create worktree for all member repos
+forester worktree list               # List existing worktrees
+forester worktree remove feature-x   # Remove a worktree
+```
+
+Forester is a standalone open-source tool that can be applied to any codebase. See `crates/forester/README.md` for complete documentation.
 
 ## brdev
 


### PR DESCRIPTION
Was reading `forester` docs and noticed that the README lists `brdev` examples under its section.