### PR TITLE
feat(forester): add update command to fetch latest changes for all repos

### DIFF
--- a/crates/forester/src/cli/mod.rs
+++ b/crates/forester/src/cli/mod.rs
@@ -3,6 +3,7 @@
 mod grove;
 mod init;
 mod seed;
+mod update;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::io::IsTerminal;
@@ -33,6 +34,8 @@ enum Command {
     Init(init::InitArgs),
     /// Clone all member repositories and set up the forest
     Seed(seed::SeedArgs),
+    /// Fetch latest changes for all member repos
+    Update(update::UpdateArgs),
     /// Manage forest groves
     #[command(subcommand)]
     Grove(grove::GroveCommand),
@@ -54,6 +57,7 @@ pub fn run() -> miette::Result<()> {
     match cli.command {
         Command::Init(args) => init::run(args),
         Command::Seed(args) => seed::run(args),
+        Command::Update(args) => update::run(args),
         Command::Grove(cmd) => grove::run(cmd),
     }
 }

--- a/crates/forester/src/cli/update.rs
+++ b/crates/forester/src/cli/update.rs
@@ -1,0 +1,48 @@
+//! Update command - fetch latest changes for all member repos.
+
+use crate::forest::ForestConfig;
+use crate::grove::ForestManager;
+use clap::Args;
+use owo_colors::OwoColorize;
+use std::path::PathBuf;
+use tracing::instrument;
+
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Path to forester.toml (default: current directory)
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+
+    /// Show verbose output
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+#[instrument(err)]
+pub fn run(args: UpdateArgs) -> miette::Result<()> {
+    let (forest_root, config) = if let Some(config_path) = args.config {
+        let config = ForestConfig::load(&config_path)?;
+        let root = config_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_path_buf();
+        (root, config)
+    } else {
+        ForestConfig::find()?
+    };
+
+    if args.verbose {
+        println!(
+            "Updating forest '{}' at {}",
+            config.forest.name.cyan(),
+            forest_root.display()
+        );
+    }
+
+    let manager = ForestManager::new(forest_root, config);
+    manager.update(args.verbose)?;
+
+    println!("{}", "✓ Forest updated successfully".green());
+
+    Ok(())
+}

--- a/crates/forester/src/grove/mod.rs
+++ b/crates/forester/src/grove/mod.rs
@@ -50,6 +50,60 @@ impl ForestManager {
         Ok(())
     }
 
+    /// Update all bare repos by fetching from remotes.
+    #[instrument(skip(self), err)]
+    pub fn update(&self, verbose: bool) -> Result<(), Error> {
+        let bare_dir = self.bare_dir();
+        if !bare_dir.exists() {
+            return Err(Error::Git {
+                message: "Forest not seeded. Run 'forester seed' first.".to_string(),
+            });
+        }
+
+        for member in &self.config.forest.member {
+            let bare_path = bare_dir.join(format!("{}.git", member.name));
+            if !bare_path.exists() {
+                if verbose {
+                    println!(
+                        "{} {} bare repo missing, skipping",
+                        "!".yellow(),
+                        member.name
+                    );
+                }
+                continue;
+            }
+
+            if verbose {
+                println!("Fetching {}...", member.name);
+            }
+
+            let status = Command::new("git")
+                .args([
+                    "fetch",
+                    &member.remote,
+                    "+refs/heads/*:refs/remotes/origin/*",
+                    "--prune",
+                ])
+                .current_dir(&bare_path)
+                .status()
+                .map_err(|_| Error::Git {
+                    message: format!("Failed to fetch {}", member.name),
+                })?;
+
+            if !status.success() {
+                return Err(Error::Git {
+                    message: format!("git fetch failed for {}", member.name),
+                });
+            }
+
+            if verbose {
+                println!("{} {} updated", "✓".green(), member.name);
+            }
+        }
+
+        Ok(())
+    }
+
     #[instrument(skip(self), err)]
     fn clone_bare(&self, member: &Member, verbose: bool) -> Result<(), Error> {
         let bare_path = self.bare_dir().join(format!("{}.git", member.name));

--- a/crates/forester/tests/common/mod.rs
+++ b/crates/forester/tests/common/mod.rs
@@ -47,6 +47,15 @@ pub fn forester_grove(cwd: &Path, subcmd: &str, args: &[&str]) -> (i32, String, 
     forester_cmd(cwd, &full_args)
 }
 
+/// Run forester update in the given directory
+pub fn forester_update(cwd: &Path, verbose: bool) -> (i32, String, String) {
+    let mut args = vec!["update"];
+    if verbose {
+        args.push("--verbose");
+    }
+    forester_cmd(cwd, &args)
+}
+
 /// Create a temp directory for testing
 pub fn temp_forest() -> TempDir {
     TempDir::new().expect("Failed to create temp directory")

--- a/crates/forester/tests/update.rs
+++ b/crates/forester/tests/update.rs
@@ -1,0 +1,123 @@
+//! Integration tests for forester update command.
+
+mod common;
+
+use common::{create_bare_repo, forester_seed, forester_update, temp_forest};
+use std::fs;
+use std::process::Command;
+
+fn setup_forest_with_local_repos() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = temp_forest();
+
+    let repos_dir = temp.path().join("repos");
+    fs::create_dir_all(&repos_dir).unwrap();
+
+    let repo_a = create_bare_repo(&repos_dir, "repo-a");
+
+    let forester_toml = format!(
+        r#"[forest]
+name = "test-forest"
+
+[[forest.member]]
+name = "repo-a"
+remote = "{}"
+path = "repo-a"
+default_branch = "main"
+"#,
+        repo_a.display()
+    );
+    fs::write(temp.path().join("forester.toml"), forester_toml).unwrap();
+    fs::write(temp.path().join("crumbly.toml"), "targets = [\".\"]\n").unwrap();
+
+    (temp, repo_a)
+}
+
+fn add_commit_to_bare_repo(bare_repo: &std::path::Path, message: &str) {
+    let temp = tempfile::TempDir::new().unwrap();
+
+    Command::new("git")
+        .args(["clone", bare_repo.to_str().unwrap(), "."])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+
+    fs::write(temp.path().join("new-file.txt"), message).unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "origin", "main"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+}
+
+#[test]
+fn update_fetches_new_commits() {
+    let (temp, remote_repo) = setup_forest_with_local_repos();
+
+    let (code, _, _) = forester_seed(temp.path(), false);
+    assert_eq!(code, 0);
+
+    add_commit_to_bare_repo(&remote_repo, "new commit");
+
+    let (code, stdout, stderr) = forester_update(temp.path(), true);
+    assert_eq!(code, 0, "Update failed: {} {}", stdout, stderr);
+
+    let output = Command::new("git")
+        .args(["log", "--oneline", "refs/remotes/origin/main"])
+        .current_dir(temp.path().join(".forest/bare/repo-a.git"))
+        .output()
+        .unwrap();
+    let log = String::from_utf8_lossy(&output.stdout);
+    assert!(log.contains("new commit"));
+}
+
+#[test]
+fn update_succeeds_with_no_changes() {
+    let (temp, _) = setup_forest_with_local_repos();
+
+    let (code, _, _) = forester_seed(temp.path(), false);
+    assert_eq!(code, 0);
+
+    let (code, stdout, stderr) = forester_update(temp.path(), true);
+    assert_eq!(code, 0, "Update failed: {} {}", stdout, stderr);
+    assert!(stdout.contains("updated") || stdout.contains("✓"));
+}
+
+#[test]
+fn update_fails_if_not_seeded() {
+    let temp = temp_forest();
+
+    let forester_toml = r#"[forest]
+name = "test-forest"
+
+[[forest.member]]
+name = "repo-a"
+remote = "/nonexistent"
+path = "repo-a"
+"#;
+    fs::write(temp.path().join("forester.toml"), forester_toml).unwrap();
+
+    let (code, _, stderr) = forester_update(temp.path(), false);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("not seeded") || stderr.contains("seed"));
+}


### PR DESCRIPTION
Closes: https://github.com/cbgbt/bottlerocket-forest/issues/9

## Description

Adds a new `forester update` command that fetches the latest commits from upstream remotes into the local bare repos.

### Changes
- `cli/mod.rs` - Add `Update` command variant
- `cli/update.rs` - New CLI handler with `-c/--config` and `-v/--verbose` flags
- `grove/mod.rs` - Add `update()` method to `ForestManager` that runs `git fetch` on each bare repo
- `tests/update.rs` - Integration tests for the new command

### Usage
```bash
forester update        # Fetch all bare repos
forester update -v     # Verbose output
```

Fetches to `refs/remotes/origin/*` rather than directly to `refs/heads/*` to avoid conflicts with branches checked out in existing groves.

## Testing
```bash
# Unit tests pass
cargo test --package forester --test update

# Manual test
cd /path/to/forest
forester seed -v
forester update -v   # Should show "✓ <repo> updated" for each member
```

Three integration tests added:
- `update_fetches_new_commits` - Verifies new upstream commits are fetched
- `update_succeeds_with_no_changes` - Works when nothing new to fetch
- `update_fails_if_not_seeded` - Errors appropriately if forest not seeded