### PR TITLE
fix(forester): use kebab-case in forester.toml

### DIFF
--- a/forester.toml
+++ b/forester.toml
@@ -5,49 +5,49 @@ name = "bottlerocket"
 name = "bottlerocket"
 remote = "git@github.com:bottlerocket-os/bottlerocket.git"
 path = "bottlerocket"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "core-kit"
 remote = "git@github.com:bottlerocket-os/bottlerocket-core-kit.git"
 path = "kits/bottlerocket-core-kit"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "kernel-kit"
 remote = "git@github.com:bottlerocket-os/bottlerocket-kernel-kit.git"
 path = "kits/bottlerocket-kernel-kit"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "twoliter"
 remote = "git@github.com:bottlerocket-os/twoliter.git"
 path = "twoliter"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "sdk"
 remote = "git@github.com:bottlerocket-os/bottlerocket-sdk.git"
 path = "sdk/bottlerocket-sdk"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "admin-container"
 remote = "git@github.com:bottlerocket-os/bottlerocket-admin-container.git"
 path = "host-containers/bottlerocket-admin-container"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "control-container"
 remote = "git@github.com:bottlerocket-os/bottlerocket-control-container.git"
 path = "host-containers/bottlerocket-control-container"
-default_branch = "develop"
+default-branch = "develop"
 
 [[forest.member]]
 name = "settings-sdk"
 remote = "git@github.com:bottlerocket-os/bottlerocket-settings-sdk.git"
 path = "bottlerocket-settings-sdk"
-default_branch = "develop"
+default-branch = "develop"
 
 [grove]
 [[grove.symlink]]


### PR DESCRIPTION
## Notes

After https://github.com/cbgbt/bottlerocket-forest/commit/824cdf24d52cf31a75a7641da56e1d5f04f0638d, `forester seed` fails with:
```
2026-01-15T00:19:35.680964Z ERROR run: forester::cli::seed: error=Failed to parse config from /Volumes/workplace/bottlerocket-forest-fork/forester.toml
Error:   × Failed to parse config from /Volumes/workplace/bottlerocket-forest-fork/forester.toml
  ╰─▶ TOML parse error at line 8, column 1
        |
      8 | default_branch = "develop"
        | ^^^^^^^^^^^^^^
      unknown field `default_branch`, expected one of `name`, `remote`, `path`, `default-branch`
```

Updating forester config to kebab-case to resolve this.

## Testing
`forester seed` is now successful