### PR TITLE
feat: Add AMI test skill

### DIFF
--- a/skills/test-ami-eks/SKILL.md
+++ b/skills/test-ami-eks/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: test-ami-eks
+description: Register a Bottlerocket AMI and launch it on EKS for validation
+---
+
+# Test AMI on EKS
+
+Register a Bottlerocket image as an AMI, track it, and launch it on an EKS cluster for validation.
+
+## When to Use
+
+- After building a Bottlerocket variant image
+- To validate custom packages or configurations work on real infrastructure
+- For integration testing before release
+
+## Prerequisites
+
+- Built Bottlerocket image in `bottlerocket/build/images/`
+- AWS credentials with EC2 and EKS permissions
+- `eksctl`, `kubectl`, `aws` CLI installed
+- `jq` for JSON parsing
+
+## Procedure
+
+### Stage 1: Register AMI
+
+From the grove root (or bottlerocket directory):
+
+```bash
+# Auto-detect variant from latest build
+./skills/test-ami-eks/register-ami.sh
+
+# Or specify variant explicitly
+./skills/test-ami-eks/register-ami.sh --variant aws-k8s-1.34
+
+# Custom options
+./skills/test-ami-eks/register-ami.sh \
+    --variant aws-k8s-1.34 \
+    --arch x86_64 \
+    --region us-west-2 \
+    --tracking ./test_builds.toml
+```
+
+Outputs the AMI ID on the last line for piping.
+
+### Stage 2: Launch on EKS
+
+```bash
+# Launch with AMI ID from register step
+# NOTE: This will delete any existing nodegroups in the cluster first
+./skills/test-ami-eks/launch-eks-nodegroup.sh --ami ami-0123456789abcdef0
+
+# Full options
+./skills/test-ami-eks/launch-eks-nodegroup.sh \
+    --ami ami-0123456789abcdef0 \
+    --cluster br-test-cluster \
+    --nodegroup br-test-ng \
+    --region us-west-2 \
+    --instance-type m5.large \
+    --capacity 2
+
+# Keep existing nodegroups (don't auto-delete)
+./skills/test-ami-eks/launch-eks-nodegroup.sh \
+    --ami ami-0123456789abcdef0 \
+    --keep-old
+```
+
+Creates cluster if it doesn't exist, then creates nodegroup.
+
+### Stage 3: Validate
+
+```bash
+# Check nodes joined
+kubectl get nodes -o wide
+
+# Check Bottlerocket version
+kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.osImage}'
+
+# SSH via admin container (if enabled)
+apiclient exec admin
+```
+
+### Stage 4: Cleanup
+
+```bash
+# Delete nodegroup only (keep cluster for reuse)
+./skills/test-ami-eks/cleanup-nodegroup.sh \
+    --cluster br-test-cluster \
+    --nodegroup br-test-ng
+
+# Delete cluster too
+./skills/test-ami-eks/cleanup-nodegroup.sh \
+    --cluster br-test-cluster \
+    --nodegroup br-test-ng \
+    --delete-cluster
+```
+
+### List Tracked Builds
+
+```bash
+# Show all builds
+./skills/test-ami-eks/list-builds.sh --tracking ./test_builds.toml
+
+# Last 5 builds
+./skills/test-ami-eks/list-builds.sh --last 5
+
+# Filter by variant
+./skills/test-ami-eks/list-builds.sh --variant aws-k8s-1.34
+```
+
+## Files
+
+| File | Purpose |
+|------|--------|
+| `register-ami.sh` | Register image as AMI, track in TOML |
+| `launch-eks-nodegroup.sh` | Create cluster/nodegroup with AMI |
+| `cleanup-nodegroup.sh` | Delete nodegroup/cluster |
+| `list-builds.sh` | Display tracked builds |
+| `eksctl-nodegroup.yaml.template` | eksctl config template |
+
+## Tracking File Format
+
+`test_builds.toml`:
+
+```toml
+default_region = "us-west-2"
+default_cluster = "br-test-cluster"
+default_instance_type = "m5.large"
+
+[[builds]]
+number = 1
+variant = "aws-k8s-1.34"
+arch = "x86_64"
+region = "us-west-2"
+timestamp = "2026-02-05T17:00:00Z"
+ami_id = "ami-0123456789abcdef0"
+ami_name = "aws-k8s-1.34-test-1"
+```
+
+## Validation Scripts
+
+### Smoke Test via SSM
+
+Run basic validation commands on nodes via SSM:
+
+```bash
+# Test all nodes in nodegroup
+./skills/test-ami-eks/smoke-test.sh \
+    --cluster br-test-cluster \
+    --nodegroup br-test-ng
+
+# Test specific instance
+./skills/test-ami-eks/smoke-test.sh --instance i-0123456789abcdef0
+```
+
+Checks:
+- SSM connectivity
+- System reached multi-user target
+- Basic system health
+
+### Get Console Output
+
+If SSM fails, check console output for boot issues:
+
+```bash
+# Get console output
+./skills/test-ami-eks/get-console.sh --instance i-0123456789abcdef0
+
+# Raw output only (for parsing)
+./skills/test-ami-eks/get-console.sh --instance i-0123456789abcdef0 --raw
+```
+
+## Common Issues
+
+**"No valid AWS credentials"**
+- Run `aws sts get-caller-identity` to verify credentials
+- Ensure credentials have EC2 and EKS permissions
+
+**"Could not detect variant"**
+- Specify `--variant` explicitly
+- Ensure image was built in `bottlerocket/build/images/`
+
+**"Nodegroup already exists"**
+- Run `cleanup-nodegroup.sh` first to delete existing nodegroup
+
+**Nodes not joining cluster**
+- Check security groups allow node-to-control-plane communication
+- Verify IAM roles have required policies
+- Check `kubectl describe node` for errors

--- a/skills/test-ami-eks/cleanup-nodegroup.sh
+++ b/skills/test-ami-eks/cleanup-nodegroup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# Clean up EKS nodegroup (and optionally cluster)
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Delete an EKS nodegroup
+
+Options:
+    --cluster NAME          Cluster name (default: br-test-cluster)
+    --nodegroup NAME        Nodegroup name (default: br-test-ng)
+    --region REGION         AWS region (default: us-west-2)
+    --delete-cluster        Also delete the cluster
+    -h, --help              Show this help
+EOF
+    exit 1
+}
+
+# Defaults
+CLUSTER_NAME="br-test-cluster"
+NODEGROUP_NAME="br-test-ng"
+REGION="us-west-2"
+DELETE_CLUSTER=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --cluster) CLUSTER_NAME="$2"; shift 2 ;;
+        --nodegroup) NODEGROUP_NAME="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        --delete-cluster) DELETE_CLUSTER=true; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if ! aws sts get-caller-identity &>/dev/null; then
+    echo "Error: No valid AWS credentials"
+    exit 1
+fi
+
+# Delete nodegroup
+if eksctl get nodegroup --cluster "$CLUSTER_NAME" --region "$REGION" --name "$NODEGROUP_NAME" &>/dev/null; then
+    echo "Deleting nodegroup $NODEGROUP_NAME..."
+    eksctl delete nodegroup \
+        --cluster "$CLUSTER_NAME" \
+        --region "$REGION" \
+        --name "$NODEGROUP_NAME" \
+        --wait
+    echo "✓ Nodegroup deleted"
+else
+    echo "Nodegroup $NODEGROUP_NAME not found"
+fi
+
+# Optionally delete cluster
+if [[ "$DELETE_CLUSTER" == "true" ]]; then
+    if eksctl get cluster --name "$CLUSTER_NAME" --region "$REGION" &>/dev/null; then
+        echo "Deleting cluster $CLUSTER_NAME..."
+        eksctl delete cluster --name "$CLUSTER_NAME" --region "$REGION" --wait
+        echo "✓ Cluster deleted"
+    else
+        echo "Cluster $CLUSTER_NAME not found"
+    fi
+fi

--- a/skills/test-ami-eks/eksctl-nodegroup.yaml.template
+++ b/skills/test-ami-eks/eksctl-nodegroup.yaml.template
@@ -1,0 +1,22 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: ${CLUSTER_NAME}
+  region: ${REGION}
+nodeGroups:
+  - name: ${NODEGROUP_NAME}
+    instanceType: ${INSTANCE_TYPE}
+    desiredCapacity: ${DESIRED_CAPACITY}
+    ami: ${AMI_ID}
+    amiFamily: Bottlerocket
+    iam:
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    bottlerocket:
+      settings:
+        host-containers:
+          admin:
+            enabled: true

--- a/skills/test-ami-eks/get-console.sh
+++ b/skills/test-ami-eks/get-console.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get EC2 console output for debugging boot issues
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --instance INSTANCE_ID [OPTIONS]
+
+Get EC2 console output (forces latest fetch)
+
+Required:
+    --instance ID       EC2 instance ID
+
+Options:
+    --region REGION     AWS region (default: us-west-2)
+    --raw               Output raw console text only
+    -h, --help          Show this help
+EOF
+    exit 1
+}
+
+INSTANCE_ID=""
+REGION="us-west-2"
+RAW=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --instance) INSTANCE_ID="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        --raw) RAW=true; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [[ -z "$INSTANCE_ID" ]]; then
+    echo "Error: --instance is required"
+    usage
+fi
+
+if [[ "$RAW" == "true" ]]; then
+    aws ec2 get-console-output \
+        --instance-id "$INSTANCE_ID" \
+        --region "$REGION" \
+        --latest \
+        --query 'Output' \
+        --output text
+else
+    echo "Console output for $INSTANCE_ID (region: $REGION)"
+    echo "================================================"
+    aws ec2 get-console-output \
+        --instance-id "$INSTANCE_ID" \
+        --region "$REGION" \
+        --latest \
+        --query 'Output' \
+        --output text
+fi

--- a/skills/test-ami-eks/launch-eks-nodegroup.sh
+++ b/skills/test-ami-eks/launch-eks-nodegroup.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+set -euo pipefail
+
+# Launch an EKS nodegroup with a custom Bottlerocket AMI
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --ami AMI_ID [OPTIONS]
+
+Launch an EKS nodegroup with a custom Bottlerocket AMI
+
+Required:
+    --ami AMI_ID            AMI ID to use
+
+Options:
+    --cluster NAME          Cluster name (default: br-test-cluster)
+    --nodegroup NAME        Nodegroup name (default: br-test-ng)
+    --region REGION         AWS region (default: us-west-2)
+    --instance-type TYPE    Instance type (default: m5.large)
+    --capacity N            Desired capacity (default: 2)
+    --k8s-version VER       Kubernetes version (default: 1.31)
+    --keep-old              Don't delete old nodegroups (default: delete them)
+    -h, --help              Show this help
+EOF
+    exit 1
+}
+
+# Defaults
+AMI_ID=""
+CLUSTER_NAME="br-test-cluster"
+NODEGROUP_NAME="br-test-ng"
+REGION="us-west-2"
+INSTANCE_TYPE="m5.large"
+DESIRED_CAPACITY="2"
+K8S_VERSION="1.31"
+KEEP_OLD=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ami) AMI_ID="$2"; shift 2 ;;
+        --cluster) CLUSTER_NAME="$2"; shift 2 ;;
+        --nodegroup) NODEGROUP_NAME="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
+        --capacity) DESIRED_CAPACITY="$2"; shift 2 ;;
+        --k8s-version) K8S_VERSION="$2"; shift 2 ;;
+        --keep-old) KEEP_OLD=true; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [[ -z "$AMI_ID" ]]; then
+    echo "Error: --ami is required"
+    usage
+fi
+
+# Check prerequisites
+for cmd in eksctl kubectl aws; do
+    if ! command -v $cmd &>/dev/null; then
+        echo "Error: $cmd is required but not installed"
+        exit 1
+    fi
+done
+
+if ! aws sts get-caller-identity &>/dev/null; then
+    echo "Error: No valid AWS credentials"
+    exit 1
+fi
+
+echo "Cluster: $CLUSTER_NAME"
+echo "Nodegroup: $NODEGROUP_NAME"
+echo "AMI: $AMI_ID"
+echo "Region: $REGION"
+echo ""
+
+# Check if cluster exists
+if eksctl get cluster --name "$CLUSTER_NAME" --region "$REGION" &>/dev/null; then
+    echo "✓ Cluster $CLUSTER_NAME exists"
+    
+    # Delete old nodegroups unless --keep-old is specified
+    if [[ "$KEEP_OLD" == "false" ]]; then
+        echo "Checking for existing nodegroups to clean up..."
+        OLD_NODEGROUPS=$(eksctl get nodegroup --cluster "$CLUSTER_NAME" --region "$REGION" -o json 2>/dev/null | jq -r '.[].Name' || true)
+        
+        for ng in $OLD_NODEGROUPS; do
+            if [[ -n "$ng" ]]; then
+                echo "Deleting old nodegroup: $ng"
+                eksctl delete nodegroup --cluster "$CLUSTER_NAME" --region "$REGION" --name "$ng" --drain=false --disable-eviction || true
+            fi
+        done
+        
+        # Wait for deletions to complete
+        if [[ -n "$OLD_NODEGROUPS" ]]; then
+            echo "Waiting for nodegroup deletions to complete..."
+            sleep 30
+        fi
+    fi
+else
+    echo "Creating cluster $CLUSTER_NAME..."
+    eksctl create cluster         --name "$CLUSTER_NAME"         --region "$REGION"         --version "$K8S_VERSION"         --without-nodegroup
+    echo "✓ Cluster created"
+    
+    echo "Installing default addons..."
+    # VPC CNI for pod networking
+    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.19/config/master/aws-k8s-cni.yaml
+    # kube-proxy for service networking
+    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/auth.yaml 2>/dev/null || true
+    echo "✓ Addons installed"
+fi
+
+# Render template
+TEMPLATE="$SCRIPT_DIR/eksctl-nodegroup.yaml.template"
+CONFIG_FILE=$(mktemp /tmp/eksctl-config-XXXXXX.yaml)
+
+export CLUSTER_NAME REGION NODEGROUP_NAME INSTANCE_TYPE DESIRED_CAPACITY AMI_ID
+envsubst < "$TEMPLATE" > "$CONFIG_FILE"
+
+echo "Creating nodegroup..."
+eksctl create nodegroup -f "$CONFIG_FILE"
+
+rm -f "$CONFIG_FILE"
+
+# Wait for nodes and show status
+echo ""
+echo "Waiting for nodes to be ready..."
+kubectl wait --for=condition=Ready nodes -l eks.amazonaws.com/nodegroup="$NODEGROUP_NAME" --timeout=300s 2>/dev/null || true
+
+echo ""
+echo "Node status:"
+kubectl get nodes -l eks.amazonaws.com/nodegroup="$NODEGROUP_NAME" -o wide
+
+echo ""
+echo "✓ Nodegroup $NODEGROUP_NAME launched with AMI $AMI_ID"

--- a/skills/test-ami-eks/list-builds.sh
+++ b/skills/test-ami-eks/list-builds.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# List tracked AMI builds
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+List tracked AMI builds from test_builds.toml
+
+Options:
+    --tracking FILE     Path to test_builds.toml (default: ./test_builds.toml)
+    --last N            Show only last N builds
+    --variant VAR       Filter by variant
+    -h, --help          Show this help
+EOF
+    exit 1
+}
+
+# Defaults
+TRACKING_FILE="./test_builds.toml"
+LAST_N=""
+VARIANT_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tracking) TRACKING_FILE="$2"; shift 2 ;;
+        --last) LAST_N="$2"; shift 2 ;;
+        --variant) VARIANT_FILTER="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [[ ! -f "$TRACKING_FILE" ]]; then
+    echo "Error: Tracking file not found: $TRACKING_FILE"
+    exit 1
+fi
+
+# Parse and display builds
+echo "AMI Builds from $TRACKING_FILE"
+echo "======================================"
+printf "%-4s %-25s %-8s %-25s %s\n" "#" "VARIANT" "ARCH" "AMI_ID" "TIMESTAMP"
+echo "--------------------------------------"
+
+# Simple awk parser for TOML builds
+awk -v filter="$VARIANT_FILTER" '
+    /^\[\[builds\]\]/ { in_build=1; num=""; var=""; arch=""; ami=""; ts=""; next }
+    in_build && /^number = / { gsub(/number = /, ""); num=$0 }
+    in_build && /^variant = / { gsub(/variant = "|"/,""); var=$0 }
+    in_build && /^arch = / { gsub(/arch = "|"/,""); arch=$0 }
+    in_build && /^ami_id = / { gsub(/ami_id = "|"/,""); ami=$0 }
+    in_build && /^timestamp = / { gsub(/timestamp = "|"/,""); ts=$0 }
+    in_build && /^$/ {
+        if (num != "" && (filter == "" || var ~ filter)) {
+            printf "%-4s %-25s %-8s %-25s %s\n", num, var, arch, ami, ts
+        }
+        in_build=0
+    }
+    END {
+        if (in_build && num != "" && (filter == "" || var ~ filter)) {
+            printf "%-4s %-25s %-8s %-25s %s\n", num, var, arch, ami, ts
+        }
+    }
+' "$TRACKING_FILE" | if [[ -n "$LAST_N" ]]; then tail -n "$LAST_N"; else cat; fi

--- a/skills/test-ami-eks/register-ami.sh
+++ b/skills/test-ami-eks/register-ami.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+set -euo pipefail
+
+# Register a Bottlerocket image as an AMI and track it
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Register a Bottlerocket image as an AMI and track in test_builds.toml
+
+Options:
+    --variant VAR       Variant name (e.g., aws-k8s-1.34)
+    --arch ARCH         Architecture (default: x86_64)
+    --region REGION     AWS region (default: us-west-2)
+    --name NAME         Custom AMI name (auto-generated if not specified)
+    --tracking FILE     Path to test_builds.toml (default: ./test_builds.toml)
+    -h, --help          Show this help
+EOF
+    exit 1
+}
+
+# Defaults
+ARCH="x86_64"
+REGION="us-west-2"
+VARIANT=""
+AMI_NAME=""
+TRACKING_FILE="./test_builds.toml"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --variant) VARIANT="$2"; shift 2 ;;
+        --arch) ARCH="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        --name) AMI_NAME="$2"; shift 2 ;;
+        --tracking) TRACKING_FILE="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# Must be in bottlerocket directory or have it as subdirectory
+if [[ -d "bottlerocket" ]]; then
+    BR_DIR="bottlerocket"
+elif [[ -f "Twoliter.toml" ]]; then
+    BR_DIR="."
+else
+    echo "Error: Must run from directory containing bottlerocket/ or from bottlerocket repo"
+    exit 1
+fi
+
+# Auto-detect variant from latest build if not specified
+if [[ -z "$VARIANT" ]]; then
+    BUILD_DIR="$BR_DIR/build/images"
+    if [[ -d "$BUILD_DIR" ]]; then
+        LATEST=$(ls -1 "$BUILD_DIR" | grep "^${ARCH}-" | head -1)
+        if [[ -n "$LATEST" ]]; then
+            VARIANT=${LATEST#${ARCH}-}
+            echo "Auto-detected variant: $VARIANT"
+        fi
+    fi
+fi
+
+if [[ -z "$VARIANT" ]]; then
+    echo "Error: Could not detect variant. Specify with --variant"
+    exit 1
+fi
+
+# Check AWS credentials
+if ! aws sts get-caller-identity &>/dev/null; then
+    echo "Error: No valid AWS credentials"
+    exit 1
+fi
+
+# Calculate next build number
+if [[ -f "$TRACKING_FILE" ]]; then
+    BUILD_COUNT=$(grep -c '^number = ' "$TRACKING_FILE" 2>/dev/null || echo "0")
+else
+    BUILD_COUNT=0
+    # Create tracking file with defaults
+    cat > "$TRACKING_FILE" <<EOF
+# AMI Build Tracking
+default_region = "$REGION"
+default_cluster = "br-test-cluster"
+default_instance_type = "m5.large"
+EOF
+fi
+NEXT_BUILD=$((BUILD_COUNT + 1))
+
+# Generate AMI name if not specified
+TIMESTAMP=$(date -u +"%Y%m%d-%H%M%S")
+if [[ -z "$AMI_NAME" ]]; then
+    AMI_NAME="${VARIANT}-test-${NEXT_BUILD}"
+fi
+AMI_DESC="${AMI_NAME}_${TIMESTAMP}"
+
+echo "Build #$NEXT_BUILD: $VARIANT ($ARCH)"
+echo "AMI Name: $AMI_NAME"
+
+# Run cargo make ami
+cd "$BR_DIR"
+cargo make \
+    -e BUILDSYS_VARIANT="$VARIANT" \
+    -e BUILDSYS_ARCH="$ARCH" \
+    -e PUBLISH_REGIONS="$REGION" \
+    -e PUBLISH_AMI_NAME="$AMI_NAME" \
+    -e PUBLISH_AMI_DESCRIPTION="$AMI_DESC" \
+    ami
+
+# Find and extract AMI ID from amis.json
+AMIS_JSON=$(find "build/images/${ARCH}-${VARIANT}/latest" -name '*-amis.json' | head -1)
+if [[ -z "$AMIS_JSON" ]] || [[ ! -f "$AMIS_JSON" ]]; then
+    echo "Error: Could not find amis.json"
+    exit 1
+fi
+
+AMI_ID=$(jq -r ".\"${REGION}\".id" "$AMIS_JSON")
+if [[ -z "$AMI_ID" ]] || [[ "$AMI_ID" == "null" ]]; then
+    echo "Error: Could not extract AMI ID for region $REGION"
+    exit 1
+fi
+
+cd - >/dev/null
+
+# Record in tracking file
+cat >> "$TRACKING_FILE" <<EOF
+
+[[builds]]
+number = $NEXT_BUILD
+variant = "$VARIANT"
+arch = "$ARCH"
+region = "$REGION"
+timestamp = "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+ami_id = "$AMI_ID"
+ami_name = "$AMI_NAME"
+EOF
+
+echo ""
+echo "✓ AMI registered: $AMI_ID"
+echo "✓ Build #$NEXT_BUILD recorded in $TRACKING_FILE"
+echo ""
+echo "$AMI_ID"

--- a/skills/test-ami-eks/smoke-test.sh
+++ b/skills/test-ami-eks/smoke-test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+set -euo pipefail
+
+# Basic smoke test via SSM - verify instance reached multi-user
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run smoke test on Bottlerocket nodes via SSM
+
+Options:
+    --instance ID           Test specific instance
+    --cluster NAME          Get instances from EKS nodegroup
+    --nodegroup NAME        Nodegroup name (requires --cluster)
+    --region REGION         AWS region (default: us-west-2)
+    -h, --help              Show this help
+
+Examples:
+    $(basename "$0") --instance i-0123456789abcdef0
+    $(basename "$0") --cluster br-test-cluster --nodegroup br-test-ng
+EOF
+    exit 1
+}
+
+INSTANCE_ID=""
+CLUSTER_NAME=""
+NODEGROUP_NAME=""
+REGION="us-west-2"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --instance) INSTANCE_ID="$2"; shift 2 ;;
+        --cluster) CLUSTER_NAME="$2"; shift 2 ;;
+        --nodegroup) NODEGROUP_NAME="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [[ -z "$INSTANCE_ID" ]] && [[ -z "$CLUSTER_NAME" ]]; then
+    echo "Error: Specify --instance or --cluster/--nodegroup"
+    usage
+fi
+
+# Get instance IDs from nodegroup if not specified directly
+if [[ -n "$CLUSTER_NAME" ]]; then
+    if [[ -z "$NODEGROUP_NAME" ]]; then
+        NODEGROUP_NAME="br-test-ng"
+    fi
+    
+    echo "Getting instances from nodegroup $NODEGROUP_NAME..."
+    INSTANCES=$(aws ec2 describe-instances \
+        --region "$REGION" \
+        --filters \
+            "Name=tag:eks:cluster-name,Values=$CLUSTER_NAME" \
+            "Name=tag:eks:nodegroup-name,Values=$NODEGROUP_NAME" \
+            "Name=instance-state-name,Values=running" \
+        --query 'Reservations[].Instances[].InstanceId' \
+        --output text)
+    
+    if [[ -z "$INSTANCES" ]]; then
+        echo "Error: No running instances found in nodegroup"
+        exit 1
+    fi
+else
+    INSTANCES="$INSTANCE_ID"
+fi
+
+run_smoke_test() {
+    local instance=$1
+    echo ""
+    echo "Testing instance: $instance"
+    echo "--------------------------------"
+    
+    # Check SSM connectivity
+    if ! aws ssm describe-instance-information \
+        --region "$REGION" \
+        --filters "Key=InstanceIds,Values=$instance" \
+        --query 'InstanceInformationList[0].PingStatus' \
+        --output text | grep -q "Online"; then
+        echo "✗ SSM not available - checking console output..."
+        "$SCRIPT_DIR/get-console.sh" --instance "$instance" --region "$REGION" | tail -50
+        return 1
+    fi
+    echo "✓ SSM online"
+    
+    # Run smoke test commands via SSM -> apiclient exec admin
+    echo "Running smoke test commands..."
+    
+    COMMANDS='apiclient exec admin bash -c "systemctl is-system-running; systemctl status multi-user.target --no-pager; uptime"'
+    
+    RESULT=$(aws ssm send-command \
+        --region "$REGION" \
+        --instance-ids "$instance" \
+        --document-name "AWS-RunShellScript" \
+        --parameters "commands=[$COMMANDS]" \
+        --query 'Command.CommandId' \
+        --output text)
+    
+    # Wait for command
+    sleep 5
+    
+    OUTPUT=$(aws ssm get-command-invocation \
+        --region "$REGION" \
+        --command-id "$RESULT" \
+        --instance-id "$instance" \
+        --query '[Status, StandardOutputContent, StandardErrorContent]' \
+        --output text 2>/dev/null || echo "Pending")
+    
+    STATUS=$(echo "$OUTPUT" | head -1)
+    
+    if [[ "$STATUS" == "Success" ]]; then
+        echo "$OUTPUT" | tail -n +2
+        if echo "$OUTPUT" | grep -q "running\|degraded"; then
+            echo "✓ System reached multi-user target"
+            return 0
+        else
+            echo "✗ System may not have fully booted"
+            return 1
+        fi
+    else
+        echo "Command status: $STATUS"
+        echo "$OUTPUT"
+        return 1
+    fi
+}
+
+FAILED=0
+for instance in $INSTANCES; do
+    if ! run_smoke_test "$instance"; then
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+echo ""
+if [[ $FAILED -eq 0 ]]; then
+    echo "✓ All smoke tests passed"
+    exit 0
+else
+    echo "✗ $FAILED instance(s) failed smoke test"
+    exit 1
+fi


### PR DESCRIPTION
I built this skill to validate AMI builds while iterating. It currently uses `eksctl` to launch new node groups and names the AMIs in a way that allows iteration without losing the old AMIs. 