### PR TITLE
feat(forester): add pre-hooks

### DIFF
--- a/crates/forester/src/hooks/context.rs
+++ b/crates/forester/src/hooks/context.rs
@@ -35,6 +35,10 @@ impl HookContext {
     }
 
     /// Returns environment variables for hook execution.
+    ///
+    /// `GROVE_PATH` may not exist on disk depending on the trigger:
+    /// `PreGroveCreate` runs before the grove is created,
+    /// `PostGroveRemove` runs after the grove is deleted.
     pub fn env_vars(&self) -> Vec<(&'static str, String)> {
         let mut vars = vec![
             ("FOREST_ROOT", self.forest_root.path().display().to_string()),

--- a/crates/forester/src/hooks/trigger.rs
+++ b/crates/forester/src/hooks/trigger.rs
@@ -5,10 +5,16 @@ use std::fmt;
 /// Events that can trigger hook execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Trigger {
+    /// Before seeding the forest.
+    PreSeed,
     /// After seeding the forest.
     PostSeed,
+    /// Before creating a grove.
+    PreGroveCreate,
     /// After creating a grove.
     PostGroveCreate,
+    /// Before removing a grove.
+    PreGroveRemove,
     /// After removing a grove.
     PostGroveRemove,
 }
@@ -17,8 +23,11 @@ impl Trigger {
     /// Parses a trigger from a string.
     pub fn parse(s: &str) -> Option<Self> {
         match s {
+            "pre-seed" => Some(Self::PreSeed),
             "post-seed" => Some(Self::PostSeed),
+            "pre-grove-create" => Some(Self::PreGroveCreate),
             "post-grove-create" => Some(Self::PostGroveCreate),
+            "pre-grove-remove" => Some(Self::PreGroveRemove),
             "post-grove-remove" => Some(Self::PostGroveRemove),
             _ => None,
         }
@@ -27,8 +36,11 @@ impl Trigger {
     /// Returns the string representation.
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::PreSeed => "pre-seed",
             Self::PostSeed => "post-seed",
+            Self::PreGroveCreate => "pre-grove-create",
             Self::PostGroveCreate => "post-grove-create",
+            Self::PreGroveRemove => "pre-grove-remove",
             Self::PostGroveRemove => "post-grove-remove",
         }
     }

--- a/crates/forester/src/ops/grove_create.rs
+++ b/crates/forester/src/ops/grove_create.rs
@@ -58,6 +58,11 @@ impl<'a> GroveCreateOperation<'a> {
             });
         }
 
+        let pre_ctx = self.hook_context(name, &grove_path, Trigger::PreGroveCreate);
+        self.hooks
+            .run_hooks(Trigger::PreGroveCreate, &pre_ctx)
+            .context(HookSnafu)?;
+
         std::fs::create_dir_all(&grove_path).context(CreateDirSnafu { path: &grove_path })?;
         std::fs::create_dir_all(grove_root.marker_dir()).context(CreateDirSnafu {
             path: grove_root.marker_dir(),
@@ -80,9 +85,9 @@ gitdir: /dev/null
 
         self.create_symlinks(&grove_path, self.forest_root.path())?;
 
-        let ctx = self.hook_context(name, &grove_path);
+        let post_ctx = self.hook_context(name, &grove_path, Trigger::PostGroveCreate);
         self.hooks
-            .run_hooks(Trigger::PostGroveCreate, &ctx)
+            .run_hooks(Trigger::PostGroveCreate, &post_ctx)
             .context(HookSnafu)?;
 
         self.emitter.emit(&ForesterEvent::GroveCreated {
@@ -178,10 +183,10 @@ gitdir: /dev/null
         Ok(())
     }
 
-    fn hook_context(&self, name: &GroveName, path: &Path) -> HookContext {
+    fn hook_context(&self, name: &GroveName, path: &Path, trigger: Trigger) -> HookContext {
         HookContext::builder()
             .forest_root(self.forest_root.clone())
-            .trigger(Trigger::PostGroveCreate)
+            .trigger(trigger)
             .emitter(Arc::clone(&self.emitter))
             .grove_name(name.to_string())
             .grove_path(path.to_path_buf())

--- a/crates/forester/src/ops/grove_remove.rs
+++ b/crates/forester/src/ops/grove_remove.rs
@@ -49,11 +49,16 @@ impl<'a> GroveRemoveOperation<'a> {
             name: name.to_string(),
         });
 
+        let pre_ctx = self.hook_context(name, &grove_path, Trigger::PreGroveRemove);
+        self.hooks
+            .run_hooks(Trigger::PreGroveRemove, &pre_ctx)
+            .context(HookSnafu)?;
+
         std::fs::remove_dir_all(&grove_path).context(RemoveDirSnafu { path: &grove_path })?;
 
-        let ctx = self.hook_context(name, &grove_path);
+        let post_ctx = self.hook_context(name, &grove_path, Trigger::PostGroveRemove);
         self.hooks
-            .run_hooks(Trigger::PostGroveRemove, &ctx)
+            .run_hooks(Trigger::PostGroveRemove, &post_ctx)
             .context(HookSnafu)?;
 
         self.emitter.emit(&ForesterEvent::GroveRemoved {
@@ -62,10 +67,10 @@ impl<'a> GroveRemoveOperation<'a> {
         Ok(())
     }
 
-    fn hook_context(&self, name: &GroveName, path: &Path) -> HookContext {
+    fn hook_context(&self, name: &GroveName, path: &Path, trigger: Trigger) -> HookContext {
         HookContext::builder()
             .forest_root(self.forest_root.clone())
-            .trigger(Trigger::PostGroveRemove)
+            .trigger(trigger)
             .emitter(Arc::clone(&self.emitter))
             .grove_name(name.to_string())
             .grove_path(path.to_path_buf())

--- a/crates/forester/src/ops/seed.rs
+++ b/crates/forester/src/ops/seed.rs
@@ -43,6 +43,11 @@ impl<'a> SeedOperation<'a> {
 
         self.emitter.emit(&ForesterEvent::SeedStarted);
 
+        let pre_ctx = self.hook_context(Trigger::PreSeed);
+        self.hooks
+            .run_hooks(Trigger::PreSeed, &pre_ctx)
+            .context(HookSnafu)?;
+
         let bare_dir = self.forest_root.bare_dir();
         std::fs::create_dir_all(&bare_dir).context(CreateDirSnafu { path: &bare_dir })?;
 
@@ -50,9 +55,9 @@ impl<'a> SeedOperation<'a> {
             self.clone_member(member)?;
         }
 
-        let ctx = self.hook_context();
+        let post_ctx = self.hook_context(Trigger::PostSeed);
         self.hooks
-            .run_hooks(Trigger::PostSeed, &ctx)
+            .run_hooks(Trigger::PostSeed, &post_ctx)
             .context(HookSnafu)?;
 
         self.emitter.emit(&ForesterEvent::SeedCompleted);
@@ -85,10 +90,10 @@ impl<'a> SeedOperation<'a> {
         Ok(())
     }
 
-    fn hook_context(&self) -> HookContext {
+    fn hook_context(&self, trigger: Trigger) -> HookContext {
         HookContext::builder()
             .forest_root(self.forest_root.clone())
-            .trigger(Trigger::PostSeed)
+            .trigger(trigger)
             .emitter(Arc::clone(&self.emitter))
             .verbose(self.verbose)
             .build()

--- a/crates/forester/tests/seed_and_grove.rs
+++ b/crates/forester/tests/seed_and_grove.rs
@@ -8,6 +8,32 @@ mod common;
 use common::{create_bare_repo, forester_grove, forester_seed, temp_forest};
 use std::fs;
 
+/// Hook config entries for forester.toml that touch marker files.
+fn hook_toml_entries() -> String {
+    let triggers = [
+        "pre-seed",
+        "post-seed",
+        "pre-grove-create",
+        "post-grove-create",
+        "pre-grove-remove",
+        "post-grove-remove",
+    ];
+    triggers
+        .iter()
+        .map(|t| {
+            format!(
+                r#"
+[[hook]]
+name = "exec"
+triggers = ["{t}"]
+path = "/bin/sh"
+args = ["-c", "touch $FOREST_ROOT/.{t}-ran"]
+"#
+            )
+        })
+        .collect::<String>()
+}
+
 fn setup_forest_with_local_repos() -> tempfile::TempDir {
     let temp = temp_forest();
 
@@ -38,6 +64,7 @@ default_branch = "main"
         repo_a.display(),
         repo_b.display()
     );
+    let forester_toml = format!("{}{}", forester_toml, hook_toml_entries());
     fs::write(temp.path().join("forester.toml"), forester_toml).unwrap();
 
     // Create crumbly.toml
@@ -60,6 +87,16 @@ fn seed_clones_bare_repos() {
     // And: Bare repos are created
     assert!(temp.path().join(".forest/bare/repo-a.git").exists());
     assert!(temp.path().join(".forest/bare/repo-b.git").exists());
+
+    // And: Pre and post seed hooks ran
+    assert!(
+        temp.path().join(".pre-seed-ran").exists(),
+        "pre-seed hook did not run"
+    );
+    assert!(
+        temp.path().join(".post-seed-ran").exists(),
+        "post-seed hook did not run"
+    );
 }
 
 #[test]
@@ -117,6 +154,16 @@ fn grove_create_makes_new_grove() {
     assert!(temp.path().join("groves/feature-x").exists());
     assert!(temp.path().join("groves/feature-x/repo-a").exists());
     assert!(temp.path().join("groves/feature-x/nested/repo-b").exists());
+
+    // And: Pre and post grove-create hooks ran
+    assert!(
+        temp.path().join(".pre-grove-create-ran").exists(),
+        "pre-grove-create hook did not run"
+    );
+    assert!(
+        temp.path().join(".post-grove-create-ran").exists(),
+        "post-grove-create hook did not run"
+    );
 }
 
 #[test]
@@ -155,6 +202,16 @@ fn grove_remove_deletes_grove() {
 
     // And: Other grove still exists
     assert!(temp.path().join("groves/feature-y").exists());
+
+    // And: Pre and post grove-remove hooks ran
+    assert!(
+        temp.path().join(".pre-grove-remove-ran").exists(),
+        "pre-grove-remove hook did not run"
+    );
+    assert!(
+        temp.path().join(".post-grove-remove-ran").exists(),
+        "post-grove-remove hook did not run"
+    );
 }
 
 #[test]
@@ -183,9 +240,10 @@ fn no_repos_at_forest_root() {
                 ".forest",
                 ".crumbly",
                 "groves",
-                "repos"
+                "repos",
             ]
-            .contains(&entry.as_str()),
+            .contains(&entry.as_str())
+                || entry.starts_with('.') && entry.ends_with("-ran"),
             "Unexpected entry at forest root: {}",
             entry
         );


### PR DESCRIPTION
### Description
Extending hook functionality to allow for pre-hooks. 
I had a use case, where I was using a hook post seed creation, but needed to clean up that action, pre removal.

### Testing
* Added to the seed_and_grove integration test
* Setup my own hooks for pre and post runs - verified it worked. 
