### PR TITLE
feat: add Kubernetes lifecycle skills

### DIFF
--- a/skills/add-kubernetes-prerelease/SKILL.md
+++ b/skills/add-kubernetes-prerelease/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: add-kubernetes-prerelease
+description: Package Kubernetes pre-release (beta/rc) sources from EKS-D before GA
+---
+
+# Add Kubernetes Pre-Release
+
+Package Kubernetes beta/rc versions from EKS-D pre-release artifacts.
+
+## Purpose
+
+Creates ecr-credential-provider and kubernetes packages for pre-release versions (beta, rc) using EKS-D pre-release artifacts.
+Differs from production packaging by using pre-release URLs and version strings with suffixes.
+
+## When to Use
+
+- Testing new Kubernetes versions before GA release
+- EKS-D pre-release artifacts are available
+- Need to validate breaking changes early
+
+## Prerequisites
+
+- Run `analyze-kubernetes-release` skill first
+- EKS-D pre-release artifacts published at https://distro.eks.amazonaws.com/kubernetes-{major}-{minor}/releases/
+- Working in bottlerocket-core-kit repository (or forest worktree)
+- Previous Kubernetes version packages exist to copy from
+
+## Tracking
+
+Create a tracking issue following this pattern:
+https://github.com/bottlerocket-os/bottlerocket/issues/4620
+
+Checklist items:
+- [ ] Use pre-release sources in packages (this skill)
+- [ ] Use official GA sources in packages (promote-kubernetes-ga)
+- [ ] Add variants for k8s version (bottlerocket repo)
+
+## Procedure
+
+### 1. Set Version Variables
+
+```bash
+# Set versions (example: adding 1.NN based on 1.MM)
+PREV_VERSION="1.MM"      # e.g., "1.34"
+NEW_VERSION="1.NN"       # e.g., "1.35"
+PREV_VER_NODOT="1MM"     # e.g., "134" (used in package names)
+NEW_VER_NODOT="1NN"      # e.g., "135"
+PRERELEASE_TAG="beta.0"  # or "rc.1", etc.
+FULL_VERSION="${NEW_VERSION}.0-${PRERELEASE_TAG}"
+
+# Verify analysis exists
+ANALYSIS="$FOREST_ROOT/planning/k8s-${NEW_VERSION}-analysis.md"
+if [ ! -f "$ANALYSIS" ]; then
+    echo "ERROR: Run analyze-kubernetes-release first"
+    exit 1
+fi
+
+cd kits/bottlerocket-core-kit/packages
+```
+
+### 2. Verify Pre-release Sources Exist
+
+**Critical:** Verify EKS-D pre-release artifacts are published before making any changes.
+
+```bash
+# Construct pre-release URLs
+RELEASE="1"  # EKS-D release number, typically "1" for first pre-release
+K8S_URL="https://distro.eks.amazonaws.com/kubernetes-${NEW_VERSION}/releases/${RELEASE}/artifacts/kubernetes/v${FULL_VERSION}/kubernetes-src.tar.gz"
+ECR_URL="https://distro.eks.amazonaws.com/kubernetes-${NEW_VERSION}/releases/${RELEASE}/artifacts/plugins/v${FULL_VERSION}/eks-distro-ecr-credential-provider-linux-amd64-v${FULL_VERSION}.tar.gz"
+
+# Verify kubernetes source exists
+if ! curl -sfI "$K8S_URL" > /dev/null; then
+    echo "ERROR: Kubernetes source not found at $K8S_URL"
+    echo "Check https://distro.eks.amazonaws.com/kubernetes-${NEW_VERSION}/releases/ for available releases"
+    exit 1
+fi
+
+# Verify ecr-credential-provider source exists
+if ! curl -sfI "$ECR_URL" > /dev/null; then
+    echo "ERROR: ECR credential provider not found at $ECR_URL"
+    echo "Check https://distro.eks.amazonaws.com/kubernetes-${NEW_VERSION}/releases/ for available releases"
+    exit 1
+fi
+
+echo "✓ Pre-release sources verified"
+```
+
+### 2. Copy ecr-credential-provider Package
+
+```bash
+cp -r ecr-credential-provider-${PREV_VER_NODOT} ecr-credential-provider-${NEW_VER_NODOT}
+cd ecr-credential-provider-${NEW_VER_NODOT}
+
+# Update Cargo.toml
+sed -i "s/ecr-credential-provider-${PREV_VER_NODOT}/ecr-credential-provider-${NEW_VER_NODOT}/g" Cargo.toml
+sed -i "s/${PREV_VERSION}/${NEW_VERSION}/g" Cargo.toml
+
+# Update spec file
+mv ecr-credential-provider-${PREV_VER_NODOT}.spec ecr-credential-provider-${NEW_VER_NODOT}.spec
+sed -i "s/${PREV_VERSION}/${NEW_VERSION}/g" ecr-credential-provider-${NEW_VER_NODOT}.spec
+
+cd ..
+```
+
+### 4. Copy kubernetes Package
+
+```bash
+cp -r kubernetes-${PREV_VER_NODOT} kubernetes-${NEW_VER_NODOT}
+cd kubernetes-${NEW_VER_NODOT}
+
+# Update Cargo.toml
+sed -i "s/kubernetes-${PREV_VER_NODOT}/kubernetes-${NEW_VER_NODOT}/g" Cargo.toml
+sed -i "s/${PREV_VERSION}/${NEW_VERSION}/g" Cargo.toml
+
+# Update spec file
+mv kubernetes-${PREV_VER_NODOT}.spec kubernetes-${NEW_VER_NODOT}.spec
+sed -i "s/${PREV_VERSION}/${NEW_VERSION}/g" kubernetes-${NEW_VER_NODOT}.spec
+sed -i "s/${PREV_VER_NODOT}/${NEW_VER_NODOT}/g" kubernetes-${NEW_VER_NODOT}.spec
+
+# Update template and systemd files
+find . -type f \( -name "*.service" -o -name "*.conf" -o -name "*.toml" -o -name "*.env" \) \
+    -exec sed -i "s/${PREV_VERSION}/${NEW_VERSION}/g" {} \;
+
+cd ../..
+```
+
+### 5. Apply Breaking Changes from Analysis
+
+**Critical:** Review the KEP analysis document and apply necessary changes.
+
+Common changes between Kubernetes versions:
+- Removed kubelet flags (check kubelet-exec-start-conf)
+- New kubelet config options (check kubelet-config)
+- Deprecated features requiring opt-in/opt-out
+
+Refer to `$FOREST_ROOT/planning/k8s-${NEW_VERSION}-analysis.md` for version-specific changes.
+
+### 6. Update Source URLs and Release Field
+
+**Critical:** Pre-release URLs differ from production URLs.
+
+Format: `https://distro.eks.amazonaws.com/kubernetes-{major}-{minor}/releases/{release}/artifacts/kubernetes/v{version}/...`
+
+**Version Variables for Pre-release:**
+
+The pre-release status is indicated in the Release field, NOT in Version.
+
+**Example spec file structure:**
+
+```spec
+# Version variables - use clean version, pre-release in Release field only
+%global gover 1.35.0
+%global rpmver %{gover}
+
+Name: %{_cross_os}kubernetes
+Version: %{rpmver}
+Release: 0.beta0%{?dist}
+
+# Hardcode Source0 with actual pre-release version (will update for GA)
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-35/releases/1/artifacts/kubernetes/v1.35.0-beta.0/kubernetes-src.tar.gz
+```
+
+⚠️ **Why this matters:**
+- Version field stays clean (1.35.0) for RPM compatibility
+- Release field (0.beta0) sorts before GA release (1)
+- Source0 URL contains the actual pre-release tag from upstream
+
+```bash
+# Update kubernetes spec
+vim packages/kubernetes-${NEW_VER_NODOT}/kubernetes-${NEW_VER_NODOT}.spec
+# Set: %global gover ${NEW_VERSION}.0
+# Set: %global rpmver %{gover}
+# Set: Release: 0.beta0%{?dist}
+# Hardcode Source0 with full pre-release URL
+
+# Update ecr-credential-provider Cargo.toml URL
+vim packages/ecr-credential-provider-${NEW_VER_NODOT}/Cargo.toml
+# Update the url field to point to the new version
+```
+
+**Critical: Set Pre-release Release Field**
+
+For BOTH spec files, update the Release field to indicate pre-release:
+```spec
+Release: 0.beta0%{?dist}
+```
+
+Or for release candidates:
+```spec
+Release: 0.rc0%{?dist}
+```
+
+⚠️ **Why this matters:** RPM version ordering uses Release when Version is equal.
+- `0.beta0` sorts before `1` (GA release)
+- This ensures clean upgrades: pre-release → GA works correctly
+- Using `Release: 1%{?dist}` for pre-release breaks upgrade ordering
+
+The pattern is: `0.<prerelease-tag>%{?dist}` where prerelease-tag matches the source (beta0, rc0, rc1, etc.)
+
+**Check for Obsolete Patches**
+
+Review patches from the previous version:
+```bash
+# Check if patches still apply or were merged upstream
+ls packages/kubernetes-${PREV_VER_NODOT}/*.patch 2>/dev/null
+```
+
+Remove patches that were merged upstream in the new release.
+
+### 7. Update Workspace Configuration
+
+```bash
+cd ../..  # Back to core-kit root
+
+# Edit Cargo.toml to add new packages to workspace members
+vim Cargo.toml
+
+# Add to [workspace] members array:
+#   "packages/ecr-credential-provider-${NEW_VER_NODOT}",
+#   "packages/kubernetes-${NEW_VER_NODOT}",
+```
+
+### 8. Build and Validate
+
+**Required:** Run the `build-kit-locally` skill to verify packages compile correctly.
+
+This builds the kit and publishes to the local registry, confirming the new packages work.
+
+### 9. Commit Changes
+
+Create separate commits for each package (following existing PR patterns):
+
+```bash
+# Commit 1: ecr-credential-provider
+git add packages/ecr-credential-provider-${NEW_VER_NODOT}/
+# Also add Cargo.toml with just the ecr-credential-provider line
+git commit -m "packages: add ecr-credential-provider-${NEW_VER_NODOT}"
+
+# Commit 2: kubernetes
+git add packages/kubernetes-${NEW_VER_NODOT}/ Cargo.toml Cargo.lock
+git commit -m "packages: add kubernetes-${NEW_VER_NODOT}"
+```
+
+## Validation
+
+Success indicators:
+- `build-kit-locally` skill completes successfully
+- Kit visible in local registry via `brdev registry list`
+
+## Common Issues
+
+**404 on pre-release URLs:**
+- EKS-D pre-release not published yet
+- Check https://distro.eks.amazonaws.com/kubernetes-{major}-{minor}/releases/ for available releases
+- Verify release number and pre-release tag in URL
+
+**Version mismatch errors:**
+- Ensure all URLs use full pre-release version (e.g., v1.NN.0-beta.0, not v1.NN)
+- Check spec file Version field matches
+
+**Build failures from removed flags:**
+- Check KEP analysis for removed kubelet flags
+- Update kubelet-exec-start-conf to remove deprecated flags
+
+**Wrong Release field for pre-release:**
+- Symptom: RPM version conflicts when promoting to GA
+- Cause: Using `Release: 1%{?dist}` instead of `Release: 0.beta0%{?dist}`
+- Fix: Pre-release packages must use `Release: 0.<tag>%{?dist}` to sort before GA
+
+## Next Steps
+
+After successful build and commit:
+1. **Optional:** Build variant to test end-to-end (`build-variant-from-local-kits` skill)
+2. Test thoroughly - pre-release versions may have bugs
+3. When GA releases, promote to production (`promote-kubernetes-ga` skill)
+
+## Related Skills
+
+This skill is part of the Kubernetes version workflow:
+1. `analyze-kubernetes-release` - Deep analysis of KEPs and changes (run first)
+2. `add-kubernetes-prerelease` - Package beta/rc for early testing (this skill)
+3. `build-kit-locally` - Build and publish kit (included in step 7)
+4. `promote-kubernetes-ga` - Promote to GA (run after upstream GA)

--- a/skills/add-kubernetes-variant/SKILL.md
+++ b/skills/add-kubernetes-variant/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: add-kubernetes-variant
+description: Add a new Kubernetes variant to the bottlerocket repository
+---
+
+# Add Kubernetes Variant
+
+Add a new Kubernetes variant to the bottlerocket repository that consumes packages from core-kit.
+
+## Purpose
+
+After packaging Kubernetes in core-kit (via `add-kubernetes-prerelease`), this skill creates the variant definition in the bottlerocket repo that uses those packages.
+
+## When to Use
+
+- After `add-kubernetes-prerelease` has created kubernetes-{version} packages in core-kit
+- When adding support for a new Kubernetes minor version
+- When creating platform variants (aws, vmware) for a new k8s version
+
+## Prerequisites
+
+1. Core-kit with kubernetes-{version} packages published to registry
+2. Worktree created for the k8s version: `forester worktree create k8s-{version}`
+3. Reference variant exists (e.g., aws-k8s-1.34 when creating aws-k8s-1.35)
+
+## Variables
+
+Set these before starting:
+
+```bash
+PREV_VERSION="1.34"      # Previous k8s version to copy from
+NEW_VERSION="1.35"       # New k8s version
+PLATFORM="aws"           # Platform: aws, vmware, metal
+WORKTREE="k8s-1.35"      # Worktree name
+```
+
+## Procedure
+
+### Step 1: Create Settings-Defaults Directory
+
+```bash
+cd worktrees/${WORKTREE}/bottlerocket
+
+# Copy from previous version
+cp -r sources/settings-defaults/${PLATFORM}-k8s-${PREV_VERSION}       sources/settings-defaults/${PLATFORM}-k8s-${NEW_VERSION}
+
+# Update Cargo.toml package name (replace dots with underscores in version)
+PREV_UNDERSCORE=$(echo $PREV_VERSION | tr '.' '_')
+NEW_UNDERSCORE=$(echo $NEW_VERSION | tr '.' '_')
+
+sed -i "s/${PLATFORM}-k8s-${PREV_UNDERSCORE}/${PLATFORM}-k8s-${NEW_UNDERSCORE}/g"     sources/settings-defaults/${PLATFORM}-k8s-${NEW_VERSION}/Cargo.toml
+```
+
+The defaults.d/ symlinks are inherited and don't need modification.
+
+### Step 2: Create Variant Directory
+
+```bash
+# Copy variant directory
+cp -r variants/${PLATFORM}-k8s-${PREV_VERSION}       variants/${PLATFORM}-k8s-${NEW_VERSION}
+
+# Update Cargo.toml
+sed -i "s/${PLATFORM}-k8s-${PREV_UNDERSCORE}/${PLATFORM}-k8s-${NEW_UNDERSCORE}/g"     variants/${PLATFORM}-k8s-${NEW_VERSION}/Cargo.toml
+
+# Update kubelet version reference
+sed -i "s/kubelet-${PREV_VERSION}/kubelet-${NEW_VERSION}/g"     variants/${PLATFORM}-k8s-${NEW_VERSION}/Cargo.toml
+```
+
+### Step 3: Update sources/Cargo.toml
+
+Add the new settings-defaults to workspace members:
+
+```bash
+# Find the line with previous version and add new one after it
+sed -i "/settings-defaults\/${PLATFORM}-k8s-${PREV_VERSION}"/a\    \"settings-defaults/${PLATFORM}-k8s-${NEW_VERSION}\","     sources/Cargo.toml
+```
+
+### Step 4: Update Root Cargo.toml
+
+Add the new variant to workspace members:
+
+```bash
+# Add after previous version entry
+sed -i "/variants\/${PLATFORM}-k8s-${PREV_VERSION}",/a\    \"variants/${PLATFORM}-k8s-${NEW_VERSION}\","     Cargo.toml
+```
+
+### Step 5: Update settings-defaults.spec
+
+Edit `packages/settings-defaults/settings-defaults.spec`:
+
+**Add package definition block** (after the ${PREV_VERSION} block):
+
+```spec
+%package ${PLATFORM}-k8s-${NEW_VERSION}
+Summary: Settings defaults for the ${PLATFORM}-k8s ${NEW_VERSION} variants
+Requires: (%{shrink:
+           %{_cross_os}variant(${PLATFORM}-k8s-${NEW_VERSION})      or
+           %{_cross_os}variant(${PLATFORM}-k8s-${NEW_VERSION}-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(${PLATFORM}-k8s-${NEW_VERSION})
+Provides: %{_cross_os}settings-defaults(${PLATFORM}-k8s-${NEW_VERSION}-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description ${PLATFORM}-k8s-${NEW_VERSION}
+%{summary}.
+```
+
+**Add %files section** (after the ${PREV_VERSION} %files block):
+
+```spec
+%files ${PLATFORM}-k8s-${NEW_VERSION}
+%{_cross_defaultsdir}/${PLATFORM}-k8s-${NEW_VERSION}.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-${PLATFORM}-k8s-${NEW_VERSION}.conf
+```
+
+### Step 6: Update settings-plugins.spec
+
+Edit `packages/settings-plugins/settings-plugins.spec`:
+
+**Add Provides lines** to the appropriate package section (find the ${PLATFORM}-k8s package):
+
+```spec
+Provides: %{_cross_os}settings-plugin(${PLATFORM}-k8s-${NEW_VERSION})
+Provides: %{_cross_os}settings-plugin(${PLATFORM}-k8s-${NEW_VERSION}-fips)
+```
+
+### Step 7: Update README.md
+
+Add the new variant to the variants list in README.md.
+
+### Step 8: Regenerate Cargo.lock
+
+```bash
+cargo generate-lockfile
+cd sources && cargo generate-lockfile && cd ..
+```
+
+### Step 9: Commit Changes
+
+```bash
+git add -A
+git commit -m "variants: add ${PLATFORM}-k8s-${NEW_VERSION}"
+```
+
+## Validation
+
+1. Verify directories exist:
+   ```bash
+   ls variants/${PLATFORM}-k8s-${NEW_VERSION}/
+   ls sources/settings-defaults/${PLATFORM}-k8s-${NEW_VERSION}/
+   ```
+
+2. Verify Cargo.toml entries:
+   ```bash
+   grep "${PLATFORM}-k8s-${NEW_VERSION}" Cargo.toml
+   grep "${PLATFORM}-k8s-${NEW_VERSION}" sources/Cargo.toml
+   ```
+
+3. Build the variant (requires local registry with core-kit):
+   ```bash
+   cargo make -e BUILDSYS_VARIANT=${PLATFORM}-k8s-${NEW_VERSION} build-variant
+   ```
+
+## Common Issues
+
+### "package not found" during build
+- Ensure core-kit with kubernetes-${NEW_VERSION} is published to local registry
+- Check Twoliter.toml points to correct registry
+
+### Symlink errors
+- The defaults.d/ symlinks are relative paths - don't modify them
+- They should all point to ../../../shared-defaults/
+
+### Cargo.lock conflicts
+- Run `cargo generate-lockfile` in both root and sources/ directories
+
+## Notes
+
+- FIPS variants share settings-defaults with non-FIPS (no separate directory needed)
+- nvidia variants need separate settings-defaults (different containerd config)
+- For nvidia variants, also copy from ${PLATFORM}-k8s-${PREV_VERSION}-nvidia

--- a/skills/analyze-kubernetes-release/SKILL.md
+++ b/skills/analyze-kubernetes-release/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: analyze-kubernetes-release
+description: Analyze a Kubernetes release for Bottlerocket compatibility and required changes
+---
+
+# Analyze Kubernetes Release
+
+Analyze a new Kubernetes release to determine compatibility with Bottlerocket and identify required changes.
+
+## When to Use
+
+- New Kubernetes minor version released (e.g., 1.32)
+- Planning to add support for a new Kubernetes version
+- Evaluating breaking changes before implementation
+
+## Prerequisites
+
+- Internet access for Kubernetes release notes
+- Understanding of Bottlerocket's Kubernetes components (kubelet, kube-proxy, credential provider)
+
+## Procedure
+
+### 1. Initialize Analysis Document
+
+Set the version being analyzed:
+```bash
+K8S_VERSION="1.32"  # e.g., "1.32" for Kubernetes 1.32
+```
+
+Create `$FOREST_ROOT/planning/k8s-${K8S_VERSION}-analysis.md` with this template:
+
+```markdown
+# Kubernetes ${K8S_VERSION} Analysis for Bottlerocket
+
+**Date:** YYYY-MM-DD
+**Analyst:** 
+**Status:** In Progress
+
+## Summary
+
+Brief overview of findings.
+
+## Breaking Changes
+
+### Kubelet (SIG Node)
+
+| Change | PR/KEP | Citation |
+|--------|--------|----------|
+| None identified | | |
+
+### kube-proxy (SIG Network)
+
+| Change | PR/KEP | Citation |
+|--------|--------|----------|
+| None identified | | |
+
+## Deprecations
+
+| Feature | Timeline | Citation | Bottlerocket Impact |
+|---------|----------|----------|---------------------|
+| None identified | | | |
+
+## KEP Analysis
+
+### KEP-XXXX: Title
+
+**Stage:** alpha/beta/GA
+**Impact:** High/Medium/Low
+**Summary:** {cited from KEP}
+**Citation:** {KEP URL or file path}
+**Action:** 
+
+## Dependency Updates
+
+| Component | Version | Citation | Notes |
+|-----------|---------|----------|-------|
+| Go | | | |
+| containerd API | | | |
+
+## Go/No-Go
+
+**Recommendation:** GO / NO-GO / CONDITIONAL
+**Rationale:** {based on cited facts above}
+**Blockers:** {cite specific changes}
+```
+
+### 2. Download CHANGELOG
+
+```bash
+curl -sL "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-${K8S_VERSION}.md" > /tmp/k8s-${K8S_VERSION}-changelog.md
+```
+
+### 3. Analyze Changes Using fact-find
+
+**For each category, use fact-find to get cited answers:**
+
+```
+USING SKILL "fact-find"
+
+Question: "What are the Urgent Upgrade Notes in Kubernetes {VERSION} CHANGELOG?"
+Question: "What SIG Node changes affect kubelet in Kubernetes {VERSION}?"
+Question: "What SIG Network changes affect kube-proxy in Kubernetes {VERSION}?"
+Question: "What credential provider changes are in Kubernetes {VERSION}?"
+```
+
+**Document each finding with its citation** in the analysis document.
+
+### 4. KEP Deep Dive (If Breaking Changes Found)
+
+For breaking changes identified in step 3, use fact-find to analyze the KEP:
+
+```
+USING SKILL "fact-find"
+
+Question: "What does KEP-XXXX change about kubelet behavior?"
+Question: "What configuration changes does KEP-XXXX require?"
+```
+
+### 5. Check EKS-D Status
+
+```bash
+curl -s "https://api.github.com/repos/aws/eks-distro/releases" | \
+    grep -o '"tag_name": "v1-'${K8S_VERSION//./}-'[^"]*"' | head -5
+```
+
+### 6. Make Go/No-Go Decision
+
+**Base decision on cited facts from steps 3-4.**
+
+**GO:** No blockers identified in cited changes
+- No breaking kubelet/kube-proxy changes found, OR
+- Breaking changes have simple fixes (cite specific changes)
+
+**NO-GO:** Blockers exist in cited changes
+- Kubelet flag removal requiring template changes (cite KEP/PR)
+- Config format changes (cite KEP/PR)
+- Dependency issues (cite version requirements)
+
+**CONDITIONAL:** Minor issues in cited changes
+- Deprecation warnings (cite specific deprecations)
+- Optional features can be disabled (cite feature gates)
+
+**⚠️ All recommendations must reference specific citations from the analysis.**
+
+## Validation
+
+- [ ] Analysis document created
+- [ ] All findings have citations (KEP URLs, PR numbers, CHANGELOG sections)
+- [ ] fact-find used for each analysis question
+- [ ] Go/No-Go decision references specific cited facts
+- [ ] No unsupported claims or synthesis
+
+## Common Issues
+
+**Too many results:** Focus on "Breaking" and "Deprecation" in change descriptions.
+
+**Unclear impact:** Use fact-find to ask "Does {change} affect kubelet configuration?"
+
+**Missing citations:** Every claim in the analysis must trace to a source.
+
+## Reference
+
+- [Kubernetes CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)
+- [KEPs](https://github.com/kubernetes/enhancements/tree/master/keps)
+- [SIG Node](https://github.com/kubernetes/community/tree/master/sig-node)

--- a/skills/promote-kubernetes-ga/SKILL.md
+++ b/skills/promote-kubernetes-ga/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: promote-kubernetes-ga
+description: Promote a pre-release Kubernetes version to GA by updating source URLs and removing pre-release markers
+---
+
+# Promote Kubernetes to GA
+
+Promote a pre-release Kubernetes version to GA release in bottlerocket-core-kit.
+
+## When to Use
+
+- Kubernetes version moves from pre-release (alpha/beta/rc) to GA
+- EKS-D releases the GA version
+- Pre-release packages already exist in core-kit
+
+## Prerequisites
+
+- Pre-release packages exist (kubernetes-X.Y, ecr-credential-provider-X.Y)
+- GA release available from upstream
+- EKS-D has released the GA version
+
+## Procedure
+
+### 1. Identify Version
+
+```bash
+K8S_VERSION="1.32"
+VER_NODOT="${K8S_VERSION//.}"  # "132"
+```
+
+### 2. Navigate to Packages
+
+```bash
+cd kits/bottlerocket-core-kit/packages
+```
+
+### 3. Update kubernetes Package
+
+```bash
+cd kubernetes-${VER_NODOT}
+```
+
+**Update Cargo.toml:**
+- Change source URLs from pre-release to GA
+- Update checksums for new sources
+- Remove any pre-release version suffixes
+
+**Update spec file:**
+- Remove `%global prerelease` line if present
+- Update `Release:` field: change from `0.pre.N%{?dist}` to `1%{?dist}` for GA
+- Verify `Version:` matches GA version
+
+### 4. Update ecr-credential-provider Package
+
+```bash
+cd ../ecr-credential-provider-${VER_NODOT}
+```
+
+**Update Cargo.toml:**
+- Change source URLs to GA release
+- Update checksums
+
+**Update clarify.toml:**
+- Update license hashes if sources changed
+
+```bash
+vim clarify.toml
+```
+
+### 5. Build and Validate
+
+Use the `build-kit-locally` skill to build and publish the updated core-kit:
+
+```bash
+# See skills/build-kit-locally/SKILL.md
+# This will build both packages and publish to local registry
+```
+
+## Validation
+
+Success indicators:
+- Both packages build without errors (verified by build-kit-locally skill)
+- License checks pass (clarify.toml hashes correct)
+- Source downloads succeed (GA URLs valid)
+- Kit successfully published to local registry
+
+## Common Issues
+
+**Source URL 404:** GA not yet released. Wait for upstream release.
+
+**Checksum mismatch:** Re-download and recalculate checksums.
+
+**License hash mismatch:** Source tarball contents changed. Update clarify.toml hashes.
+
+## Reference
+
+- [Kubernetes Releases](https://github.com/kubernetes/kubernetes/releases)
+- [EKS-D Releases](https://github.com/aws/eks-distro/releases)


### PR DESCRIPTION
This PR adds skills covering the Kubernetes version lifecycle in Bottlerocket, from analysis through release.

## New Skills

| Skill | Description |
|-------|-------------|
| analyze-kubernetes-release | Analyze a Kubernetes release for Bottlerocket compatibility and required changes |
| promote-kubernetes-ga | Promote a pre-release Kubernetes version to GA by updating source URLs and removing pre-release markers |
| add-kubernetes-variant | Add a new Kubernetes variant to the bottlerocket repository |
| add-kubernetes-prerelease | Package Kubernetes pre-release (beta/rc) sources from EKS-D before GA, with build verification and breaking changes analysis |